### PR TITLE
feat - 더미 앱 생성 api 구현

### DIFF
--- a/src/main/java/sopt/org/HMH/domain/dummy/DummyApp.java
+++ b/src/main/java/sopt/org/HMH/domain/dummy/DummyApp.java
@@ -1,0 +1,12 @@
+package sopt.org.HMH.domain.dummy;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Deprecated
+@Getter
+@AllArgsConstructor
+public class DummyApp {
+    String appName;
+    String appImageUrl;
+}

--- a/src/main/java/sopt/org/HMH/domain/dummy/DummyAppController.java
+++ b/src/main/java/sopt/org/HMH/domain/dummy/DummyAppController.java
@@ -1,0 +1,21 @@
+package sopt.org.HMH.domain.dummy;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sopt.org.HMH.global.common.response.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/dummy")
+@Deprecated
+public class DummyAppController {
+    @GetMapping("/app")
+    public ResponseEntity<ApiResponse<?>> orderModifyDailyChallenge() {
+        return ResponseEntity
+                .status(DummyAppSuccess.GET_DUMMY_SUCCESS.getHttpStatus())
+                .body(ApiResponse.success(DummyAppSuccess.GET_DUMMY_SUCCESS, DummyAppListResponse.of()));
+    }
+}

--- a/src/main/java/sopt/org/HMH/domain/dummy/DummyAppListResponse.java
+++ b/src/main/java/sopt/org/HMH/domain/dummy/DummyAppListResponse.java
@@ -1,0 +1,17 @@
+package sopt.org.HMH.domain.dummy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Deprecated
+public record DummyAppListResponse(
+        List<DummyApp> apps
+) {
+        public static DummyAppListResponse of() {
+                List<DummyApp> dummyAppList = new ArrayList<>();
+                dummyAppList.add(new DummyApp("Netflix","https://github.com/Team-HMH/HMH-Server/assets/69035864/dd068b83-641a-4bff-b4f5-381ea6e04d44"));
+                dummyAppList.add(new DummyApp("Instagram","https://github.com/Team-HMH/HMH-Server/assets/69035864/bd572377-9dd9-47e7-a9f4-9efbbe66cd2e"));
+                dummyAppList.add(new DummyApp("YouTube","https://github.com/Team-HMH/HMH-Server/assets/69035864/8afa60c0-bf1d-4ff0-9b50-4d1558a71f0a"));
+                return new DummyAppListResponse(dummyAppList);
+        }
+}

--- a/src/main/java/sopt/org/HMH/domain/dummy/DummyAppSuccess.java
+++ b/src/main/java/sopt/org/HMH/domain/dummy/DummyAppSuccess.java
@@ -1,0 +1,31 @@
+package sopt.org.HMH.domain.dummy;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import sopt.org.HMH.global.common.exception.base.SuccessBase;
+
+@AllArgsConstructor
+@Deprecated
+public enum DummyAppSuccess implements SuccessBase {
+
+    GET_DUMMY_SUCCESS(HttpStatus.OK, "더미 데이터 가져오기에 성공하였습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String successMessage;
+
+    @Override
+    public int getHttpStatusCode() {
+        return this.status.value();
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getSuccessMessage() {
+        return this.successMessage;
+    }
+}

--- a/src/main/java/sopt/org/HMH/global/config/SecurityConfig.java
+++ b/src/main/java/sopt/org/HMH/global/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
 
     private static final String[] AUTH_WHITELIST = {
-            "/", "/error", "/health",
+            "/", "/error", "/health", "/api/v1/dummy/**",
 
             // Swagger
             "/swagger-ui/**",


### PR DESCRIPTION
<!--- 
❗️ check List 
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

❗️ 이슈 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
- deploy 배포 관련
-->

## Related issue 🚀
- closed #73 

## Work Description 💚
- 유튜브, 넷플릭스, 인스타그램 이름 및 이미지 url 반환 api 생성

## PR 참고 사항
- @Depricated 설정을 통해 데모데이 이후 삭제하도록 설정해놓았습니다. (또한 dummy 폴더에 모아놓아 dummy 폴더만을 삭제하면 되도록 하였습니다.)
- AUTH_WHITELIST에 더미 데이터 반환 엔드포인트를 추가하여 인증되지 않더라도 반환 값을 받을 수 있도록 구현하였습니다.