### PR TITLE
fix - 회원 탈퇴시 연관된 challenge, dailychallenge, app 삭제 기능 구현

### DIFF
--- a/src/main/java/sopt/org/HMH/domain/challenge/domain/Challenge.java
+++ b/src/main/java/sopt/org/HMH/domain/challenge/domain/Challenge.java
@@ -26,7 +26,7 @@ public class Challenge extends BaseTimeEntity {
     private Integer period;
     private Long goalTime;
 
-    @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<DailyChallenge> dailyChallenges  = new ArrayList<>();
 
     @Builder

--- a/src/main/java/sopt/org/HMH/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/sopt/org/HMH/domain/challenge/repository/ChallengeRepository.java
@@ -1,6 +1,6 @@
 package sopt.org.HMH.domain.challenge.repository;
 
-import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sopt.org.HMH.domain.challenge.domain.Challenge;
@@ -9,13 +9,9 @@ import sopt.org.HMH.domain.challenge.domain.exception.ChallengeException;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
-    default Challenge findByUserIdAndCreatedAtBetweenOrThrowException(Long userId, LocalDateTime startDate, LocalDateTime endDate) {
-        return findByUserIdAndCreatedAtBetween(userId, startDate, endDate).orElseThrow(() -> new ChallengeException(
-                ChallengeError.CHALLENGE_NOT_FOUND));
-    }
-    Optional<Challenge> findByUserIdAndCreatedAtBetween(Long userId, LocalDateTime startDate, LocalDateTime endDate);
-
     Optional<Challenge> findFirstByUserIdOrderByCreatedAtDesc(Long userId);
+
+    void deleteByUserIdIn(List<Long> UserId);
 
     default Challenge findFirstByUserIdOrderByCreatedAtDescOrElseThrow(Long userId) {
         return findFirstByUserIdOrderByCreatedAtDesc(userId).orElseThrow(() -> new ChallengeException(

--- a/src/main/java/sopt/org/HMH/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/sopt/org/HMH/domain/challenge/service/ChallengeService.java
@@ -83,4 +83,9 @@ public class ChallengeService {
             throw new ChallengeException(ChallengeError.INVALID_GOAL_TIME_NULL);
         }
     }
+
+    @Transactional
+    public void deleteChallengeRelatedByUserId(List<Long> expiredUserIdList) {
+        challengeRepository.deleteByUserIdIn(expiredUserIdList);
+    }
 }

--- a/src/main/java/sopt/org/HMH/domain/dailychallenge/domain/DailyChallenge.java
+++ b/src/main/java/sopt/org/HMH/domain/dailychallenge/domain/DailyChallenge.java
@@ -32,7 +32,7 @@ public class DailyChallenge extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Status status;
 
-    @OneToMany(mappedBy = "dailyChallenge", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "dailyChallenge", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<App> apps = new ArrayList<>();
 
     @Builder

--- a/src/main/java/sopt/org/HMH/domain/user/repository/UserRepository.java
+++ b/src/main/java/sopt/org/HMH/domain/user/repository/UserRepository.java
@@ -4,10 +4,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 import sopt.org.HMH.domain.user.domain.User;
 import sopt.org.HMH.domain.user.domain.exception.UserError;
 import sopt.org.HMH.domain.user.domain.exception.UserException;
@@ -25,10 +23,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
                 UserError.NOT_FOUND_USER));
     }
 
-    @Modifying
-    @Query("DELETE FROM User u WHERE u.isDeleted = true AND u.deletedAt < :currentDate")
-    void deleteUsersScheduledForDeletion(@Param("currentDate") LocalDateTime currentDate);
+    @Query("SELECT u.id FROM User u WHERE u.deletedAt < :now AND u.isDeleted = true")
+    List<Long> findIdByDeletedAtBeforeAndIsDeletedIsTrue(@Param("now") LocalDateTime now);
 
     Optional<User> findBySocialPlatformAndSocialId(SocialPlatform socialPlatform, String socialId);
+
     boolean existsBySocialPlatformAndSocialId(SocialPlatform socialPlatform, String socialId);
 }

--- a/src/main/java/sopt/org/HMH/domain/user/service/ExpiredUserDeleteScheduler.java
+++ b/src/main/java/sopt/org/HMH/domain/user/service/ExpiredUserDeleteScheduler.java
@@ -5,17 +5,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import sopt.org.HMH.domain.user.repository.UserRepository;
 
 @Component
 @RequiredArgsConstructor
 @Transactional
 public class ExpiredUserDeleteScheduler {
 
-    private final UserRepository userRepository;
+    private final UserService userService;
 
     @Scheduled(cron = "0 0 4 * * ?")
     public void deleteExpiredUser() {
-        userRepository.deleteUsersScheduledForDeletion(LocalDateTime.now());
+        userService.deleteExpiredUser(LocalDateTime.now());
     }
 }

--- a/src/main/java/sopt/org/HMH/domain/user/service/UserService.java
+++ b/src/main/java/sopt/org/HMH/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package sopt.org.HMH.domain.user.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -178,10 +179,16 @@ public class UserService {
         Long onboardingInfoId = onboardingInfoRepository.save(onboardingInfo).getId();
 
         List<OnboardingProblem> problemList = request.onboardingRequest().problemList().stream()
-                .map(problem ->  OnboardingProblem.builder()
+                .map(problem -> OnboardingProblem.builder()
                         .onboardingInfoId(onboardingInfoId)
                         .problem(problem).build())
                 .toList();
         problemRepository.saveAll(problemList);
+    }
+
+    public void deleteExpiredUser(LocalDateTime currentDate) {
+        List<Long> expiredUserList = userRepository.findIdByDeletedAtBeforeAndIsDeletedIsTrue(currentDate);
+        userRepository.deleteAllById(expiredUserList);
+        challengeService.deleteChallengeRelatedByUserId(expiredUserList);
     }
 }


### PR DESCRIPTION
<!--- 
❗️ check List 
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

❗️ 이슈 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
- deploy 배포 관련
-->

## Related issue 🚀
- closed #91 

## Work Description 💚
- 회원 탈퇴시에 만료된 유저 아이디의 리스트를 받아옵니다.
- 만료된 유저 아이디의 리스트에 있는 유저를 삭제합니다.
- 유저 아이디를 fk로 가지고 있는 챌린지를 삭제합니다.
- 삭제한 챌린지와 연관된 일별 챌린지가 cascade를 통해 삭제됩니다.
- 삭제된 일별챌린지와 연관된 app이 cascade를 통해 삭제됩니다.

## PR 참고 사항
- cron을 통한 테스트 해본 결과 SQL 쿼리가 정상적으로 실행되는 것을 확인했습니다!