### PR TITLE
fix -자정 챌린지 정보 업데이트 로직 수정

### DIFF
--- a/src/main/java/sopt/org/HMH/domain/dailychallenge/domain/exception/DailyChallengeError.java
+++ b/src/main/java/sopt/org/HMH/domain/dailychallenge/domain/exception/DailyChallengeError.java
@@ -8,6 +8,7 @@ import sopt.org.HMH.global.common.exception.base.ErrorBase;
 public enum DailyChallengeError implements ErrorBase {
 
     DAILY_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "일별 챌린지를 찾을 수 없습니다."),
+    DAILY_CHALLENGE_YESTERDAY_NOT_FOUND(HttpStatus.NOT_FOUND, "어제의 일별 챌린지를 찾을 수 없습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/sopt/org/HMH/domain/dailychallenge/domain/exception/DailyChallengeSuccess.java
+++ b/src/main/java/sopt/org/HMH/domain/dailychallenge/domain/exception/DailyChallengeSuccess.java
@@ -8,7 +8,7 @@ import sopt.org.HMH.global.common.exception.base.SuccessBase;
 public enum DailyChallengeSuccess implements SuccessBase {
 
     GET_DAILY_CHALLENGE_SUCCESS(HttpStatus.OK, "오늘의 일별 챌린지 이용 통계 조회를 성공하였습니다."),
-    MODIFY_DAILY_CHALLENGE_STATUS_SUCCESS(HttpStatus.OK, "오늘의 일별 챌린지 STATUS 변경 업데이트를 성공하였습니다"),
+    MODIFY_DAILY_CHALLENGE_STATUS_SUCCESS(HttpStatus.OK, "어제의 일별 챌린지 STATUS 변경 업데이트를 성공하였습니다"),
     MODIFY_DAILY_CHALLENGE_STATUS_FAILURE_SUCCESS(HttpStatus.OK, "오늘의 일별 챌린지 STATUS 실패 처리를 성공하였습니다"),
     ;
 


### PR DESCRIPTION
<!--- 
❗️ check List 
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

❗️ 이슈 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
- deploy 배포 관련
-->

## Related issue 🚀
- closed #97 

## Work Description 💚
- 자정 챌린지 정보 업데이트 시 자정이면 다음날이 되어 오늘의 챌린지 정보 업데이트가 아닌 '어제'의 챌린지 정보 업데이트로 수정했습니다.

## PR 참고 사항
- 진작 수정했어야 하는데 지금에서야 오류 발견한 점 사과드립니다..