### PR TITLE
modify - 완료된 챌린지 정보를 리스트로 보내도록 수정

### DIFF
--- a/src/main/java/sopt/org/hmh/domain/app/dto/request/AppArrayUsageTimeRequest.java
+++ b/src/main/java/sopt/org/hmh/domain/app/dto/request/AppArrayUsageTimeRequest.java
@@ -1,8 +1,0 @@
-package sopt.org.hmh.domain.app.dto.request;
-
-import java.util.List;
-
-public record AppArrayUsageTimeRequest(
-        List<AppUsageTimeRequest> apps
-) {
-}

--- a/src/main/java/sopt/org/hmh/domain/app/service/AppService.java
+++ b/src/main/java/sopt/org/hmh/domain/app/service/AppService.java
@@ -1,0 +1,46 @@
+package sopt.org.hmh.domain.app.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sopt.org.hmh.domain.app.domain.AppWithGoalTime;
+import sopt.org.hmh.domain.app.domain.AppWithUsageGoalTime;
+import sopt.org.hmh.domain.app.domain.exception.AppError;
+import sopt.org.hmh.domain.app.domain.exception.AppException;
+import sopt.org.hmh.domain.app.dto.request.AppUsageTimeRequest;
+import sopt.org.hmh.domain.app.repository.AppWithUsageGoalTimeRepository;
+import sopt.org.hmh.domain.dailychallenge.domain.DailyChallenge;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AppService {
+
+    private final AppWithUsageGoalTimeRepository appWithUsageGoalTimeRepository;
+
+    public void addAppForHistory(List<AppWithGoalTime> currentChallengeApps, List<AppUsageTimeRequest> apps,
+            DailyChallenge dailyChallenge, String os) {
+        appWithUsageGoalTimeRepository.saveAll(supplementAdditionalInfo(currentChallengeApps, apps, dailyChallenge, os));
+    }
+
+    private List<AppWithUsageGoalTime> supplementAdditionalInfo(List<AppWithGoalTime> currentChallengeApps,
+            List<AppUsageTimeRequest> apps, DailyChallenge dailyChallenge, String os) {
+        return apps.stream().map(app -> AppWithUsageGoalTime.builder()
+                .goalTime(this.getGoalTime(currentChallengeApps, app.appCode()))
+                .appCode(app.appCode())
+                .dailyChallenge(dailyChallenge)
+                .os(os)
+                .usageTime(app.usageTime())
+                .build()
+        ).toList();
+    }
+
+    private Long getGoalTime(List<AppWithGoalTime> currentChallengeApps, String appCode) {
+        return currentChallengeApps.stream()
+                .filter(currentChallengeApp -> currentChallengeApp.getAppCode().equals(appCode))
+                .findFirst()
+                .map(AppWithGoalTime::getGoalTime)
+                .orElseThrow(() -> new AppException(AppError.APP_NOT_FOUND));
+    }
+}

--- a/src/main/java/sopt/org/hmh/domain/challenge/domain/Challenge.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/domain/Challenge.java
@@ -8,8 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sopt.org.hmh.domain.app.domain.AppWithGoalTime;
-import sopt.org.hmh.domain.challenge.domain.exception.ChallengeError;
-import sopt.org.hmh.domain.challenge.domain.exception.ChallengeException;
 import sopt.org.hmh.global.common.domain.BaseTimeEntity;
 import sopt.org.hmh.domain.dailychallenge.domain.DailyChallenge;
 import java.util.ArrayList;
@@ -43,12 +41,5 @@ public class Challenge extends BaseTimeEntity {
         this.goalTime = goalTime;
         this.isChallengeFailedToday = false;
         this.apps = apps;
-    }
-
-    public void setChallengeFailedToday(boolean challengeFailedToday) {
-        if (challengeFailedToday && this.isChallengeFailedToday) {
-            throw new ChallengeException(ChallengeError.CHALLENGE_ALREADY_FAILED_TODAY);
-        }
-        this.isChallengeFailedToday = challengeFailedToday;
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/repository/ChallengeRepository.java
@@ -7,6 +7,8 @@ import sopt.org.hmh.domain.challenge.domain.Challenge;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
+    Optional<Challenge> findById(Long id);
+
     Optional<Challenge> findFirstByUserIdOrderByCreatedAtDesc(Long userId);
 
     void deleteByUserIdIn(List<Long> userId);

--- a/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
@@ -162,8 +162,18 @@ public class ChallengeService {
             throw new AppException(AppError.INVALID_TIME_RANGE);
     }
 
+    @Deprecated
     public Challenge findFirstByUserIdOrderByCreatedAtDescOrElseThrow(Long userId) {
         return challengeRepository.findFirstByUserIdOrderByCreatedAtDesc(userId).orElseThrow(
                 () -> new ChallengeException(ChallengeError.CHALLENGE_NOT_FOUND));
+    }
+
+    public Challenge findByIdOrElseThrow(Long challengeId) {
+        return challengeRepository.findById(challengeId).orElseThrow(
+                () -> new ChallengeException(ChallengeError.CHALLENGE_NOT_FOUND));
+    }
+
+    public List<AppWithGoalTime> getCurrentChallengeAppWithGoalTimeByChallengeId(Long challengeId) {
+        return this.findByIdOrElseThrow(challengeId).getApps();
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeApi.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeApi.java
@@ -7,12 +7,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import sopt.org.hmh.domain.app.dto.request.AppArrayUsageTimeRequest;
-import sopt.org.hmh.global.auth.UserId;
+import sopt.org.hmh.domain.dailychallenge.dto.request.FinishedDailyChallengeListRequest;
 import sopt.org.hmh.global.auth.jwt.JwtConstants;
 import sopt.org.hmh.global.common.response.BaseResponse;
+import sopt.org.hmh.global.common.response.EmptyJsonResponse;
 
 @Tag(name = "일별챌린지 관련 API")
 @SecurityRequirement(name = JwtConstants.AUTHORIZATION)
@@ -32,9 +30,9 @@ public interface DailyChallengeApi {
                             responseCode = "500",
                             description = "서버 내부 오류입니다.",
                             content = @Content)})
-    ResponseEntity<BaseResponse<?>> orderAddHistoryDailyChallenge(
-            @UserId @Parameter(hidden = true) final Long userId,
-            @RequestHeader("OS") final String os,
-            @RequestBody final AppArrayUsageTimeRequest request);
+    ResponseEntity<BaseResponse<EmptyJsonResponse>> orderAddHistoryDailyChallenge(
+            @Parameter(hidden = true) final Long userId,
+            final String os,
+            final FinishedDailyChallengeListRequest request);
 }
 

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
@@ -3,9 +3,9 @@ package sopt.org.hmh.domain.dailychallenge.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import sopt.org.hmh.domain.app.dto.request.AppArrayUsageTimeRequest;
 import sopt.org.hmh.domain.dailychallenge.domain.exception.DailyChallengeSuccess;
-import sopt.org.hmh.domain.dailychallenge.service.DailyChallengeService;
+import sopt.org.hmh.domain.dailychallenge.dto.request.FinishedDailyChallengeListRequest;
+import sopt.org.hmh.domain.dailychallenge.service.DailyChallengeFacade;
 import sopt.org.hmh.global.auth.UserId;
 import sopt.org.hmh.global.common.response.BaseResponse;
 import sopt.org.hmh.global.common.response.EmptyJsonResponse;
@@ -15,16 +15,16 @@ import sopt.org.hmh.global.common.response.EmptyJsonResponse;
 @RequestMapping("/api/v1/challenge/daily")
 public class DailyChallengeController implements DailyChallengeApi {
 
-    private final DailyChallengeService dailyChallengeService;
+    private final DailyChallengeFacade dailyChallengeFacade;
 
     @PostMapping
     @Override
-    public ResponseEntity<BaseResponse<?>> orderAddHistoryDailyChallenge(
+    public ResponseEntity<BaseResponse<EmptyJsonResponse>> orderAddHistoryDailyChallenge(
             @UserId final Long userId,
             @RequestHeader("OS") final String os,
-            @RequestBody final AppArrayUsageTimeRequest request
+            @RequestBody final FinishedDailyChallengeListRequest request
     ) {
-        dailyChallengeService.addHistoryDailyChallenge(userId, request.apps(), os);
+        dailyChallengeFacade.addFinishedDailyChallengeHistory(userId, request, os);
         return ResponseEntity
                 .status(DailyChallengeSuccess.ADD_HISTORY_DAILY_CHALLENGE_SUCCESS.getHttpStatus())
                 .body(BaseResponse.success(DailyChallengeSuccess.ADD_HISTORY_DAILY_CHALLENGE_SUCCESS, new EmptyJsonResponse()));

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
@@ -26,7 +26,7 @@ public class DailyChallengeController implements DailyChallengeApi {
     ) {
         dailyChallengeFacade.addFinishedDailyChallengeHistory(userId, request, os);
         return ResponseEntity
-                .status(DailyChallengeSuccess.ADD_HISTORY_DAILY_CHALLENGE_SUCCESS.getHttpStatus())
-                .body(BaseResponse.success(DailyChallengeSuccess.ADD_HISTORY_DAILY_CHALLENGE_SUCCESS, new EmptyJsonResponse()));
+                .status(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS.getHttpStatus())
+                .body(BaseResponse.success(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS, new EmptyJsonResponse()));
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
@@ -17,8 +17,8 @@ public class DailyChallengeController implements DailyChallengeApi {
 
     private final DailyChallengeFacade dailyChallengeFacade;
 
-    @PostMapping
     @Override
+    @PostMapping("/finish")
     public ResponseEntity<BaseResponse<EmptyJsonResponse>> orderAddHistoryDailyChallenge(
             @UserId final Long userId,
             @RequestHeader("OS") final String os,

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/DailyChallenge.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/DailyChallenge.java
@@ -56,8 +56,4 @@ public class DailyChallenge extends BaseTimeEntity {
     public void changeStatus(Status status) {
         this.status = status;
     }
-
-    public void addHistoryApps(List<AppWithUsageGoalTime> apps) {
-        this.apps = apps;
-    }
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/DailyChallenge.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/DailyChallenge.java
@@ -5,21 +5,16 @@ import static jakarta.persistence.GenerationType.*;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sopt.org.hmh.domain.app.domain.AppWithUsageGoalTime;
 import sopt.org.hmh.global.common.domain.BaseTimeEntity;
 import sopt.org.hmh.domain.challenge.domain.Challenge;
-
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DailyChallenge extends BaseTimeEntity {
 
@@ -32,7 +27,7 @@ public class DailyChallenge extends BaseTimeEntity {
     private Challenge challenge;
 
     @OneToMany(mappedBy = "dailyChallenge", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private final List<AppWithUsageGoalTime> apps = new ArrayList<>();
+    private List<AppWithUsageGoalTime> apps;
 
     @Enumerated(EnumType.STRING)
     private Status status;
@@ -43,7 +38,20 @@ public class DailyChallenge extends BaseTimeEntity {
 
     private LocalDate challengeDate;
 
+    @Builder
+    DailyChallenge(Challenge challenge, Long userId, Long goalTime, LocalDate challengeDate) {
+        this.challenge = challenge;
+        this.userId = userId;
+        this.goalTime = goalTime;
+        this.challengeDate = challengeDate;
+        this.status = Status.NONE;
+    }
+
     public void changeStatus(Status status) {
         this.status = status;
+    }
+
+    public void addHistoryApps(List<AppWithUsageGoalTime> apps) {
+        this.apps = apps;
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/DailyChallenge.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/DailyChallenge.java
@@ -4,6 +4,8 @@ import static jakarta.persistence.GenerationType.*;
 
 import jakarta.persistence.*;
 import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,7 +18,9 @@ import java.util.List;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DailyChallenge extends BaseTimeEntity {
 
     @Id
@@ -27,24 +31,17 @@ public class DailyChallenge extends BaseTimeEntity {
     @JoinColumn(name = "challenge_id")
     private Challenge challenge;
 
-    private Long goalTime;
+    @OneToMany(mappedBy = "dailyChallenge", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private final List<AppWithUsageGoalTime> apps = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     private Status status;
 
-    @OneToMany(mappedBy = "dailyChallenge", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private final List<AppWithUsageGoalTime> apps = new ArrayList<>();
-
-    private LocalDate challengeDate;
-
     private Long userId;
 
-    @Builder
-    public DailyChallenge(Challenge challenge, Long goalTime, Status status) {
-        this.challenge = challenge;
-        this.goalTime = goalTime;
-        this.status = status;
-    }
+    private Long goalTime;
+
+    private LocalDate challengeDate;
 
     public void changeStatus(Status status) {
         this.status = status;

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/DailyChallenge.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/DailyChallenge.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
 import sopt.org.hmh.domain.app.domain.AppWithUsageGoalTime;
 import sopt.org.hmh.global.common.domain.BaseTimeEntity;
 import sopt.org.hmh.domain.challenge.domain.Challenge;

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/DailyChallenge.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/DailyChallenge.java
@@ -40,6 +40,11 @@ public class DailyChallenge extends BaseTimeEntity {
 
     @Builder
     DailyChallenge(Challenge challenge, Long userId, Long goalTime, LocalDate challengeDate) {
+        Assert.notNull(challenge, "Challenge must not be null");
+        Assert.notNull(userId, "UserId must not be null");
+        Assert.notNull(goalTime, "GoalTime must not be null");
+        Assert.notNull(challengeDate, "ChallengeDate must not be null");
+
         this.challenge = challenge;
         this.userId = userId;
         this.goalTime = goalTime;

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/exception/DailyChallengeError.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/exception/DailyChallengeError.java
@@ -9,7 +9,7 @@ public enum DailyChallengeError implements ErrorBase {
 
     DAILY_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "일별 챌린지를 찾을 수 없습니다."),
     DAILY_CHALLENGE_YESTERDAY_NOT_FOUND(HttpStatus.NOT_FOUND, "어제의 일별 챌린지를 찾을 수 없습니다."),
-    DAILY_CHALLENGE_ALREADY_HANDLED(HttpStatus.BAD_REQUEST, "이미 처리된 일별 챌린지입니다.")
+    DAILY_CHALLENGE_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 일별 챌린지입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/exception/DailyChallengeSuccess.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/exception/DailyChallengeSuccess.java
@@ -7,7 +7,7 @@ import sopt.org.hmh.global.common.exception.base.SuccessBase;
 @AllArgsConstructor
 public enum DailyChallengeSuccess implements SuccessBase {
 
-    ADD_HISTORY_DAILY_CHALLENGE_SUCCESS(HttpStatus.OK, "어제의 일별 챌린지 업데이트를 성공하였습니다"),
+    SEND_FINISHED_DAILY_CHALLENGE_SUCCESS(HttpStatus.OK, "완료된 일별 챌린지 정보 전송을 성공하였습니다"),
     MODIFY_DAILY_CHALLENGE_STATUS_FAILURE_SUCCESS(HttpStatus.OK, "오늘의 일별 챌린지 STATUS 실패 처리를 성공하였습니다"),
     ;
 

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/dto/request/FinishedDailyChallengeListRequest.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/dto/request/FinishedDailyChallengeListRequest.java
@@ -1,0 +1,9 @@
+package sopt.org.hmh.domain.dailychallenge.dto.request;
+
+import java.util.List;
+
+public record FinishedDailyChallengeListRequest(
+        List<FinishedDailyChallengeRequest> finishedDailyChallenges
+) {
+
+}

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/dto/request/FinishedDailyChallengeRequest.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/dto/request/FinishedDailyChallengeRequest.java
@@ -1,0 +1,11 @@
+package sopt.org.hmh.domain.dailychallenge.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+import sopt.org.hmh.domain.app.dto.request.AppUsageTimeRequest;
+
+public record FinishedDailyChallengeRequest(
+        LocalDate challengeDate,
+        List<AppUsageTimeRequest> apps
+) {
+}

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
@@ -1,0 +1,25 @@
+package sopt.org.hmh.domain.dailychallenge.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sopt.org.hmh.domain.app.service.AppService;
+import sopt.org.hmh.domain.dailychallenge.domain.DailyChallenge;
+import sopt.org.hmh.domain.dailychallenge.dto.request.FinishedDailyChallengeListRequest;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DailyChallengeFacade {
+
+    private final DailyChallengeService dailyChallengeService;
+    private final AppService appService;
+
+    public void addFinishedDailyChallengeHistory(Long userId, FinishedDailyChallengeListRequest requests, String os) {
+        requests.finishedDailyChallenges().forEach(request -> {
+            DailyChallenge dailyChallenge = dailyChallengeService.findByChallengeDateAndUserIdOrThrowException(request.challengeDate(), userId);
+            dailyChallengeService.finishDailyChallengeByChangeStatus(dailyChallenge);
+            appService.addAppForHistory(request.apps(), dailyChallenge, os);
+        });
+    }
+}

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
@@ -18,7 +18,7 @@ public class DailyChallengeFacade {
     public void addFinishedDailyChallengeHistory(Long userId, FinishedDailyChallengeListRequest requests, String os) {
         requests.finishedDailyChallenges().forEach(request -> {
             DailyChallenge dailyChallenge = dailyChallengeService.findByChallengeDateAndUserIdOrThrowException(request.challengeDate(), userId);
-            dailyChallengeService.finishDailyChallengeByChangeStatus(dailyChallenge);
+            dailyChallengeService.changeStatusByCurrentStatus(dailyChallenge);
             appService.addAppForHistory(request.apps(), dailyChallenge, os);
         });
     }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
@@ -1,11 +1,15 @@
 package sopt.org.hmh.domain.dailychallenge.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sopt.org.hmh.domain.app.domain.AppWithGoalTime;
 import sopt.org.hmh.domain.app.service.AppService;
+import sopt.org.hmh.domain.challenge.service.ChallengeService;
 import sopt.org.hmh.domain.dailychallenge.domain.DailyChallenge;
 import sopt.org.hmh.domain.dailychallenge.dto.request.FinishedDailyChallengeListRequest;
+import sopt.org.hmh.domain.user.service.UserService;
 
 @Service
 @RequiredArgsConstructor
@@ -14,12 +18,16 @@ public class DailyChallengeFacade {
 
     private final DailyChallengeService dailyChallengeService;
     private final AppService appService;
+    private final ChallengeService challengeService;
+    private final UserService userService;
 
     public void addFinishedDailyChallengeHistory(Long userId, FinishedDailyChallengeListRequest requests, String os) {
         requests.finishedDailyChallenges().forEach(request -> {
             DailyChallenge dailyChallenge = dailyChallengeService.findByChallengeDateAndUserIdOrThrowException(request.challengeDate(), userId);
             dailyChallengeService.changeStatusByCurrentStatus(dailyChallenge);
-            appService.addAppForHistory(request.apps(), dailyChallenge, os);
+            Long currentChallengeId = userService.getCurrentChallengeIdByUserId(userId);
+            List<AppWithGoalTime> currentChallengeApps = challengeService.getCurrentChallengeAppWithGoalTimeByChallengeId(currentChallengeId);
+            appService.addAppForHistory(currentChallengeApps, request.apps(), dailyChallenge, os);
         });
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
@@ -4,97 +4,18 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import sopt.org.hmh.domain.app.domain.AppConstants;
-import sopt.org.hmh.domain.app.domain.AppWithUsageGoalTime;
-import sopt.org.hmh.domain.app.domain.exception.AppError;
-import sopt.org.hmh.domain.app.domain.exception.AppException;
-import sopt.org.hmh.domain.app.dto.request.AppUsageTimeRequest;
-import sopt.org.hmh.domain.app.repository.AppWithGoalTimeRepository;
-import sopt.org.hmh.domain.app.repository.AppWithUsageGoalTimeRepository;
-import sopt.org.hmh.domain.challenge.domain.Challenge;
-import sopt.org.hmh.domain.challenge.service.ChallengeService;
 import sopt.org.hmh.domain.dailychallenge.domain.DailyChallenge;
 import sopt.org.hmh.domain.dailychallenge.domain.Status;
 import sopt.org.hmh.domain.dailychallenge.domain.exception.DailyChallengeError;
 import sopt.org.hmh.domain.dailychallenge.domain.exception.DailyChallengeException;
 import sopt.org.hmh.domain.dailychallenge.repository.DailyChallengeRepository;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class DailyChallengeService {
 
-    private final ChallengeService challengeService;
     private final DailyChallengeRepository dailyChallengeRepository;
-    private final AppWithGoalTimeRepository appWithGoalTimeRepository;
-    private final AppWithUsageGoalTimeRepository appWithUsageGoalTimeRepository;
-
-    @Transactional
-    public void addHistoryDailyChallenge(Long userId, List<AppUsageTimeRequest> requests, String os) {
-        Challenge challenge = challengeService.findFirstByUserIdOrderByCreatedAtDescOrElseThrow(userId);
-        Status status = challenge.isChallengeFailedToday() ? Status.FAILURE
-                : calculateDailyChallengeStatus(userId, requests, os);
-        DailyChallenge dailyChallenge = new DailyChallenge(challenge, challenge.getGoalTime(), status);
-
-        addHistoryApps(challenge, dailyChallenge, requests, os);
-
-        dailyChallengeRepository.save(dailyChallenge);
-        challenge.setChallengeFailedToday(false);
-    }
-
-   private void addHistoryApps(Challenge challenge, DailyChallenge dailyChallenge, List<AppUsageTimeRequest> requests, String os) {
-       List<AppWithUsageGoalTime> historyApps = requests.stream()
-               .map(request -> {
-                   validateAppCode(request.appCode());
-                   validateAppTime(request.usageTime());
-                   return AppWithUsageGoalTime.builder()
-                           .dailyChallenge(dailyChallenge)
-                           .usageTime(request.usageTime())
-                           .os(os)
-                           .appCode(request.appCode())
-                           .goalTime(appWithGoalTimeRepository
-                                   .findFirstByChallengeIdAndAppCodeAndOsOrElseThrow(challenge.getId(), request.appCode(), os)
-                                   .getGoalTime())
-                           .build();
-               }).toList();
-       appWithUsageGoalTimeRepository.saveAll(historyApps);
-   }
-
-    public Status calculateDailyChallengeStatus(Long userId, List<AppUsageTimeRequest> requests, String os) {
-        Challenge challenge = challengeService.findFirstByUserIdOrderByCreatedAtDescOrElseThrow(userId);
-        long successCount = requests.stream()
-                .filter(request -> {
-                    validateModifyDailyChallenge(request.appCode(), request.usageTime());
-                    Long goalTime = appWithGoalTimeRepository.findFirstByChallengeIdAndAppCodeAndOsOrElseThrow(
-                            challenge.getId(), request.appCode(), os).getGoalTime();
-                    return (request.usageTime() <= goalTime);
-                }).count();
-        return (successCount == requests.size()) ? Status.UNEARNED : Status.FAILURE;
-    }
-
-    private void validateAppCode(String appCode) {
-        if (appCode.isEmpty()) {
-            throw new AppException(AppError.INVALID_APP_CODE_NULL);
-        }
-    }
-
-    private void validateAppTime(Long appTime) {
-        if (appTime == null) {
-            throw new AppException(AppError.INVALID_TIME_NULL);
-        }
-    }
-
-    private void validateModifyDailyChallenge(String appCode, Long usageTime) {
-        if (appCode.isEmpty()) {
-            throw new AppException(AppError.INVALID_APP_CODE_NULL);
-        }
-        if (usageTime == null) {
-            throw new AppException(AppError.INVALID_TIME_NULL);
-        }
-        if (usageTime > AppConstants.MAXIMUM_APP_TIME || usageTime < AppConstants.MINIMUM_APP_TIME)
-            throw new AppException(AppError.INVALID_TIME_RANGE);
-    }
 
     public DailyChallenge findByChallengeDateAndUserIdOrThrowException(LocalDate challengeDate, Long userId) {
         return dailyChallengeRepository.findByChallengeDateAndUserId(challengeDate, userId)
@@ -103,7 +24,22 @@ public class DailyChallengeService {
 
     public void validateDailyChallengeStatus(DailyChallenge dailyChallenge, Status expected) {
         if (dailyChallenge.getStatus() != expected) {
-            throw new DailyChallengeException(DailyChallengeError.DAILY_CHALLENGE_ALREADY_HANDLED);
+            throw new DailyChallengeException(DailyChallengeError.DAILY_CHALLENGE_ALREADY_PROCESSED);
         }
+    }
+
+    public void finishDailyChallengeByChangeStatus(DailyChallenge dailyChallenge) {
+        if (dailyChallenge.getStatus() == Status.NONE) {
+            dailyChallenge.changeStatus(Status.UNEARNED);
+            return;
+        }
+        this.handleAlreadyProcessedDailyChallenge(dailyChallenge);
+    }
+
+    private void handleAlreadyProcessedDailyChallenge(DailyChallenge dailyChallenge) {
+        if (dailyChallenge.getStatus() == Status.FAILURE) {
+            return;
+        }
+        throw new DailyChallengeException(DailyChallengeError.DAILY_CHALLENGE_ALREADY_PROCESSED);
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
@@ -28,7 +28,7 @@ public class DailyChallengeService {
         }
     }
 
-    public void finishDailyChallengeByChangeStatus(DailyChallenge dailyChallenge) {
+    public void changeStatusByCurrentStatus(DailyChallenge dailyChallenge) {
         if (dailyChallenge.getStatus() == Status.NONE) {
             dailyChallenge.changeStatus(Status.UNEARNED);
             return;

--- a/src/main/java/sopt/org/hmh/domain/user/domain/User.java
+++ b/src/main/java/sopt/org/hmh/domain/user/domain/User.java
@@ -31,6 +31,7 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
+    private Long currentChallengeId;
 
     @Enumerated(EnumType.STRING)
     private SocialPlatform socialPlatform;

--- a/src/main/java/sopt/org/hmh/domain/user/service/UserService.java
+++ b/src/main/java/sopt/org/hmh/domain/user/service/UserService.java
@@ -100,4 +100,8 @@ public class UserService {
         return userRepository.findById(userId).orElseThrow(
                 () -> new UserException(UserError.NOT_FOUND_USER));
     }
+
+    public Long getCurrentChallengeIdByUserId(Long userId) {
+        return this.findByIdOrThrowException(userId).getCurrentChallengeId();
+    }
 }


### PR DESCRIPTION
<!--- 
❗️ check List 
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

❗️ 이슈 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
- deploy 배포 관련
-->

## Related issue 🚀
- closed #120 

## Work Description 💚
- 완료된 챌린지 정보를 리스트로 보내도록 수정하였습니다.

## PR 참고 사항
- User domain에 currentChallengeId를 추가하였습니다. 이후에 챌린지 생성시에 currentChallengeId가 업데이트 되도록 로직을 수정 부탁드립니다!
- 따라서 기존에 challenge를 찾는 함수를 Deprecated 처리하고, User의 currentChallengeId로 challenge를 찾는 함수를 추가하였습니다.
- 아래는 postman 테스트 결과입니다.
<img width="488" alt="image" src="https://github.com/Team-HMH/HMH-Server/assets/69035864/0be940fe-a18d-4ae1-807f-aa6848aa0900">
