### PR TITLE
modify - 챌린지 생성 시 일수만큼 일별챌린지 생성되도록 수정

### DIFF
--- a/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
@@ -26,6 +26,7 @@ import sopt.org.hmh.domain.dailychallenge.repository.DailyChallengeRepository;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -74,9 +75,7 @@ public class ChallengeService {
 
     public ChallengeResponse getChallenge(Long userId) {
         Challenge challenge = this.findFirstByUserIdOrderByCreatedAtDescOrElseThrow(userId);
-        Integer todayIndex = Boolean.TRUE.equals(hasChallengePeriodEnded(challenge.getCreatedAt(), challenge.getPeriod()))
-                ? -1
-                : challenge.getHistoryDailyChallenges().size();
+        Integer todayIndex = calculateTodayIndex(challenge.getCreatedAt(), challenge.getPeriod());
 
         return ChallengeResponse.builder()
                 .period(challenge.getPeriod())
@@ -134,10 +133,9 @@ public class ChallengeService {
         challengeRepository.deleteByUserIdIn(expiredUserIdList);
     }
 
-    private Boolean hasChallengePeriodEnded(LocalDateTime challengeCreatedAt, Integer period) {
-        Duration duration = Duration.between(LocalDateTime.now(), challengeCreatedAt);
-        long daysDifference = duration.toDays();
-        return daysDifference >= period;
+    private Integer calculateTodayIndex(LocalDateTime challengeCreateAt, int period) {
+        int daysBetween = (int) ChronoUnit.DAYS.between(challengeCreateAt.toLocalDate(), LocalDate.now());
+        return (daysBetween >= period) ? -1 : daysBetween;
     }
 
     private void validateChallengePeriod(Integer period) {

--- a/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
@@ -43,14 +43,13 @@ public class ChallengeService {
         validateChallengePeriod(period);
         validateChallengeGoalTime(goalTime);
 
-        Optional<Challenge> previousChallenge = challengeRepository.findFirstByUserIdOrderByCreatedAtDesc(userId);
-
         Challenge challenge = challengeRepository.save(Challenge.builder()
                 .userId(userId)
                 .period(period)
                 .goalTime(goalTime)
                 .build());
 
+        Optional<Challenge> previousChallenge = challengeRepository.findFirstByUserIdOrderByCreatedAtDesc(userId);
         if (previousChallenge.isPresent()) {
             List<AppGoalTimeRequest> previousApps = previousChallenge.get().getApps().stream()
                     .map(app -> new AppGoalTimeRequest(app.getAppCode(), app.getGoalTime()))

--- a/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
@@ -21,9 +21,12 @@ import sopt.org.hmh.domain.challenge.dto.response.DailyChallengeResponse;
 import sopt.org.hmh.domain.challenge.repository.ChallengeRepository;
 import sopt.org.hmh.domain.dailychallenge.domain.DailyChallenge;
 import sopt.org.hmh.domain.dailychallenge.domain.Status;
+import sopt.org.hmh.domain.dailychallenge.repository.DailyChallengeRepository;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,6 +36,7 @@ public class ChallengeService {
 
     private final ChallengeRepository challengeRepository;
     private final AppWithGoalTimeRepository appWithGoalTimeRepository;
+    private final DailyChallengeRepository dailyChallengeRepository;
 
     @Transactional
     public Challenge addChallenge(Long userId, Integer period, Long goalTime, String os) {
@@ -53,6 +57,19 @@ public class ChallengeService {
                     .toList();
             addApps(challenge, previousApps, os);
         }
+
+        List<DailyChallenge> dailyChallenges = new ArrayList<>();
+        LocalDate startDate = challenge.getCreatedAt().toLocalDate();
+        for (int dayCount = 0; dayCount < period; dayCount++) {
+            DailyChallenge dailyChallenge = DailyChallenge.builder()
+                    .challengeDate(startDate.plusDays(dayCount))
+                    .challenge(challenge)
+                    .userId(userId)
+                    .goalTime(goalTime).build();
+            dailyChallenges.add(dailyChallenge);
+        }
+        dailyChallengeRepository.saveAll(dailyChallenges);
+
         return challenge;
     }
 


### PR DESCRIPTION
<!--- 
❗️ check List 
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

❗️ 이슈 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
- deploy 배포 관련
-->

## Related issue 🚀
- closed #121 

## Work Description 💚
- 챌린지 생성 시 챌린지 일수만큼 일별챌린지가 생성되도록 수정했습니다.(앱정보는 X, STATUS는 NONE으로)
- 그에 따라 status 정보들을 불러오는 api에서 일수만큼의 정보가 모두 불러오도록 수정이 되었고 todayIndex구하는 로직도 수정하였습니다.

## PR 참고 사항
- 현재 postman이 되지 않아 테스트를 해보지 못했습니다만 이게 외국에 있어서 그런건지 토큰이 이상한건지 확인을 해봐야할 것 같습니다🥲