### PR TITLE
feat - 유저에 저장된 챌린지 id 이용해서 챌린지 조회 방식 변경

### DIFF
--- a/src/main/java/sopt/org/hmh/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/controller/ChallengeController.java
@@ -60,7 +60,7 @@ public class ChallengeController implements ChallengeApi {
     public ResponseEntity<BaseResponse<?>> orderAddApps(@UserId final Long userId,
                                                         @RequestHeader("OS") final String os,
                                                         @RequestBody final AppArrayGoalTimeRequest requests) {
-        Challenge challenge = challengeService.findFirstByUserIdOrderByCreatedAtDescOrElseThrow(userId);
+        Challenge challenge = challengeService.findCurrentChallengeByUserId(userId);
         challengeService.addApps(challenge, requests.apps(), os);
 
         return ResponseEntity
@@ -74,7 +74,7 @@ public class ChallengeController implements ChallengeApi {
     public ResponseEntity<BaseResponse<?>> orderRemoveApp(@UserId final Long userId,
                                                           @RequestHeader("OS") final String os,
                                                           @RequestBody final AppRemoveRequest request) {
-        Challenge challenge = challengeService.findFirstByUserIdOrderByCreatedAtDescOrElseThrow(userId);
+        Challenge challenge = challengeService.findCurrentChallengeByUserId(userId);
         challengeService.removeApp(challenge, request, os);
 
         return ResponseEntity

--- a/src/main/java/sopt/org/hmh/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/repository/ChallengeRepository.java
@@ -9,7 +9,5 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
     Optional<Challenge> findById(Long id);
 
-    Optional<Challenge> findFirstByUserIdOrderByCreatedAtDesc(Long userId);
-
     void deleteByUserIdIn(List<Long> userId);
 }

--- a/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
@@ -23,8 +23,6 @@ import sopt.org.hmh.domain.dailychallenge.domain.DailyChallenge;
 import sopt.org.hmh.domain.dailychallenge.domain.Status;
 import sopt.org.hmh.domain.dailychallenge.repository.DailyChallengeRepository;
 import sopt.org.hmh.domain.user.domain.User;
-import sopt.org.hmh.domain.user.domain.exception.UserError;
-import sopt.org.hmh.domain.user.domain.exception.UserException;
 import sopt.org.hmh.domain.user.service.UserService;
 
 import java.time.LocalDate;
@@ -32,7 +30,6 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -187,12 +184,6 @@ public class ChallengeService {
         }
         if (appTime > AppConstants.MAXIMUM_APP_TIME || appTime < AppConstants.MINIMUM_APP_TIME)
             throw new AppException(AppError.INVALID_TIME_RANGE);
-    }
-
-    @Deprecated
-    public Challenge findFirstByUserIdOrderByCreatedAtDescOrElseThrow(Long userId) {
-        return challengeRepository.findFirstByUserIdOrderByCreatedAtDesc(userId).orElseThrow(
-                () -> new ChallengeException(ChallengeError.CHALLENGE_NOT_FOUND));
     }
 
     public Challenge findByIdOrElseThrow(Long challengeId) {

--- a/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
@@ -74,7 +74,7 @@ public class ChallengeService {
         dailyChallengeRepository.saveAll(dailyChallenges);
 
         user.changeCurrentChallengeId(challenge.getId());
-        
+
         return challenge;
     }
 
@@ -93,11 +93,6 @@ public class ChallengeService {
                 .apps(challenge.getApps().stream()
                         .map(app -> new AppGoalTimeResponse(app.getAppCode(), app.getGoalTime())).toList())
                 .build();
-    }
-
-    private Challenge findCurrentChallengeByUserId(Long userId) {
-        User user = userService.findByIdOrThrowException(userId);
-        return findByIdOrElseThrow(user.getCurrentChallengeId());
     }
 
     public DailyChallengeResponse getDailyChallenge(Long userId) {
@@ -189,6 +184,11 @@ public class ChallengeService {
     public Challenge findByIdOrElseThrow(Long challengeId) {
         return challengeRepository.findById(challengeId).orElseThrow(
                 () -> new ChallengeException(ChallengeError.CHALLENGE_NOT_FOUND));
+    }
+
+    public Challenge findCurrentChallengeByUserId(Long userId) {
+        User user = userService.findByIdOrThrowException(userId);
+        return findByIdOrElseThrow(user.getCurrentChallengeId());
     }
 
     public List<AppWithGoalTime> getCurrentChallengeAppWithGoalTimeByChallengeId(Long challengeId) {

--- a/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
@@ -54,9 +54,11 @@ public class ChallengeService {
                 .goalTime(goalTime)
                 .build());
 
-        Optional<Challenge> previousChallenge = challengeRepository.findFirstByUserIdOrderByCreatedAtDesc(userId);
-        if (previousChallenge.isPresent()) {
-            List<AppGoalTimeRequest> previousApps = previousChallenge.get().getApps().stream()
+        User user = userService.findByIdOrThrowException(userId);
+        Long previousChallengeId = user.getCurrentChallengeId();
+        if (previousChallengeId != null) {
+            Challenge previousChallenge = findByIdOrElseThrow(previousChallengeId);
+            List<AppGoalTimeRequest> previousApps = previousChallenge.getApps().stream()
                     .map(app -> new AppGoalTimeRequest(app.getAppCode(), app.getGoalTime()))
                     .toList();
             addApps(challenge, previousApps, os);
@@ -74,7 +76,6 @@ public class ChallengeService {
         }
         dailyChallengeRepository.saveAll(dailyChallenges);
 
-        User user = userService.findByIdOrThrowException(userId);
         user.changeCurrentChallengeId(challenge.getId());
         
         return challenge;

--- a/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
@@ -103,7 +103,7 @@ public class ChallengeService {
     }
 
     public DailyChallengeResponse getDailyChallenge(Long userId) {
-        Challenge challenge = this.findFirstByUserIdOrderByCreatedAtDescOrElseThrow(userId);
+        Challenge challenge = findCurrentChallengeByUserId(userId);
 
         return DailyChallengeResponse.builder()
                 .status(Boolean.TRUE.equals(challenge.isChallengeFailedToday())

--- a/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
@@ -81,7 +81,7 @@ public class ChallengeService {
     }
 
     public ChallengeResponse getChallenge(Long userId) {
-        Challenge challenge = this.findFirstByUserIdOrderByCreatedAtDescOrElseThrow(userId);
+        Challenge challenge = findCurrentChallengeByUserId(userId);
         Integer todayIndex = calculateTodayIndex(challenge.getCreatedAt(), challenge.getPeriod());
 
         return ChallengeResponse.builder()

--- a/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
@@ -23,6 +23,8 @@ import sopt.org.hmh.domain.dailychallenge.domain.DailyChallenge;
 import sopt.org.hmh.domain.dailychallenge.domain.Status;
 import sopt.org.hmh.domain.dailychallenge.repository.DailyChallengeRepository;
 import sopt.org.hmh.domain.user.domain.User;
+import sopt.org.hmh.domain.user.domain.exception.UserError;
+import sopt.org.hmh.domain.user.domain.exception.UserException;
 import sopt.org.hmh.domain.user.service.UserService;
 
 import java.time.LocalDate;
@@ -93,6 +95,11 @@ public class ChallengeService {
                 .apps(challenge.getApps().stream()
                         .map(app -> new AppGoalTimeResponse(app.getAppCode(), app.getGoalTime())).toList())
                 .build();
+    }
+
+    private Challenge findCurrentChallengeByUserId(Long userId) {
+        User user = userService.findByIdOrThrowException(userId);
+        return findByIdOrElseThrow(user.getCurrentChallengeId());
     }
 
     public DailyChallengeResponse getDailyChallenge(Long userId) {

--- a/src/main/java/sopt/org/hmh/domain/user/domain/exception/UserError.java
+++ b/src/main/java/sopt/org/hmh/domain/user/domain/exception/UserError.java
@@ -10,6 +10,7 @@ public enum UserError implements ErrorBase {
     // 404 NOT FOUND
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
     NOT_ENOUGH_POINTS(HttpStatus.BAD_REQUEST, "유저의 포인트가 부족합니다."),
+    NOT_FOUND_CURRENT_CHALLENGE_ID(HttpStatus.NOT_FOUND, "유저에서 현재 챌린지 id 정보를 찾을 수 없습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/sopt/org/hmh/domain/user/service/UserService.java
+++ b/src/main/java/sopt/org/hmh/domain/user/service/UserService.java
@@ -1,6 +1,8 @@
 package sopt.org.hmh.domain.user.service;
 
 import java.util.List;
+import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,6 +12,8 @@ import sopt.org.hmh.domain.auth.exception.AuthError;
 import sopt.org.hmh.domain.auth.exception.AuthException;
 import sopt.org.hmh.domain.auth.repository.OnboardingInfoRepository;
 import sopt.org.hmh.domain.auth.repository.ProblemRepository;
+import sopt.org.hmh.domain.challenge.domain.exception.ChallengeError;
+import sopt.org.hmh.domain.challenge.domain.exception.ChallengeException;
 import sopt.org.hmh.domain.user.domain.OnboardingInfo;
 import sopt.org.hmh.domain.user.domain.OnboardingProblem;
 import sopt.org.hmh.domain.user.domain.User;
@@ -102,6 +106,7 @@ public class UserService {
     }
 
     public Long getCurrentChallengeIdByUserId(Long userId) {
-        return this.findByIdOrThrowException(userId).getCurrentChallengeId();
+        return Optional.ofNullable(this.findByIdOrThrowException(userId).getCurrentChallengeId())
+                .orElseThrow(() -> new UserException(UserError.NOT_FOUND_CURRENT_CHALLENGE_ID));
     }
 }


### PR DESCRIPTION
<!--- 
❗️ check List 
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

❗️ 이슈 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
- deploy 배포 관련
-->

## Related issue 🚀
- closed #134 

## Work Description 💚
- 홈 이용시간 통계 불러오기 api => challenge 조회방식 변경
- 달성현황 정보 불러오기 api => challenge 조회방식 변경
- 스크린타임 설정할 앱 추가 api => challenge 조회방식 변경
- 스크린타임 설정할 앱 삭제 api => challenge 조회방식 변경

## PR 참고 사항
- currentChallengeId 조회 시 에러처리도 추가하였습니다.
- facade적용도 이제 작업해보려고 합니다. 이후 쭉 작업하겠습니다! (영국에서 프랑스가는 해저터널에서 얼른 해보겠슙니다 하하)