### PR TITLE
feat: 챌린지 성공 여부 전송 api 추가

### DIFF
--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeApi.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeApi.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import sopt.org.hmh.domain.dailychallenge.dto.request.FinishedDailyChallengeListRequest;
+import sopt.org.hmh.domain.dailychallenge.dto.request.FinishedDailyChallengeStatusListRequest;
 import sopt.org.hmh.global.auth.jwt.JwtConstants;
 import sopt.org.hmh.global.common.response.BaseResponse;
 import sopt.org.hmh.global.common.response.EmptyJsonResponse;
@@ -33,6 +34,13 @@ public interface DailyChallengeApi {
     ResponseEntity<BaseResponse<EmptyJsonResponse>> orderAddHistoryDailyChallenge(
             @Parameter(hidden = true) final Long userId,
             final String os,
-            final FinishedDailyChallengeListRequest request);
+            final FinishedDailyChallengeListRequest request
+    );
+
+    ResponseEntity<BaseResponse<EmptyJsonResponse>> orderChangeStatusDailyChallenge(
+            @Parameter(hidden = true) final Long userId,
+            final String os,
+            final FinishedDailyChallengeStatusListRequest request
+    );
 }
 

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
@@ -5,7 +5,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sopt.org.hmh.domain.dailychallenge.domain.exception.DailyChallengeSuccess;
 import sopt.org.hmh.domain.dailychallenge.dto.request.FinishedDailyChallengeListRequest;
+import sopt.org.hmh.domain.dailychallenge.dto.request.FinishedDailyChallengeStatusListRequest;
 import sopt.org.hmh.domain.dailychallenge.service.DailyChallengeFacade;
+import sopt.org.hmh.domain.dailychallenge.service.DailyChallengeService;
 import sopt.org.hmh.global.auth.UserId;
 import sopt.org.hmh.global.common.response.BaseResponse;
 import sopt.org.hmh.global.common.response.EmptyJsonResponse;
@@ -16,6 +18,7 @@ import sopt.org.hmh.global.common.response.EmptyJsonResponse;
 public class DailyChallengeController implements DailyChallengeApi {
 
     private final DailyChallengeFacade dailyChallengeFacade;
+    private final DailyChallengeService dailyChallengeService;
 
     @Override
     @PostMapping("/finish")
@@ -25,6 +28,19 @@ public class DailyChallengeController implements DailyChallengeApi {
             @RequestBody final FinishedDailyChallengeListRequest request
     ) {
         dailyChallengeFacade.addFinishedDailyChallengeHistory(userId, request, os);
+        return ResponseEntity
+                .status(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS.getHttpStatus())
+                .body(BaseResponse.success(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS, new EmptyJsonResponse()));
+    }
+
+    @Override
+    @PostMapping("/success")
+    public ResponseEntity<BaseResponse<EmptyJsonResponse>> orderChangeStatusDailyChallenge(
+            @UserId final Long userId,
+            @RequestHeader("OS") final String os,
+            @RequestBody final FinishedDailyChallengeStatusListRequest request
+    ) {
+        dailyChallengeService.changeDailyChallengeStatusByIsSuccess(userId, request);
         return ResponseEntity
                 .status(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS.getHttpStatus())
                 .body(BaseResponse.success(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS, new EmptyJsonResponse()));

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/dto/request/FinishedDailyChallengeStatusListRequest.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/dto/request/FinishedDailyChallengeStatusListRequest.java
@@ -1,0 +1,9 @@
+package sopt.org.hmh.domain.dailychallenge.dto.request;
+
+import java.util.List;
+
+public record FinishedDailyChallengeStatusListRequest(
+        List<FinishedDailyChallengeStatusRequest> finishedDailyChallenges
+) {
+
+}

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/dto/request/FinishedDailyChallengeStatusRequest.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/dto/request/FinishedDailyChallengeStatusRequest.java
@@ -1,0 +1,10 @@
+package sopt.org.hmh.domain.dailychallenge.dto.request;
+
+import java.time.LocalDate;
+
+public record FinishedDailyChallengeStatusRequest(
+        LocalDate challengeDate,
+        boolean isSuccess
+) {
+
+}

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
@@ -25,12 +25,17 @@ public class DailyChallengeService {
     }
 
     public void validateDailyChallengeStatus(Status dailyChallengeStatus, List<Status> expectedStatuses) {
-        expectedStatuses.forEach(expected -> {
-            if (dailyChallengeStatus != expected) {
-                throw new DailyChallengeException(DailyChallengeError.DAILY_CHALLENGE_ALREADY_PROCESSED);
+        boolean isAlreadyProcessed = true;
+        for (Status expected : expectedStatuses) {
+            if (dailyChallengeStatus == expected) {
+                isAlreadyProcessed = false;
+                break;
             }
-        });
+        }
 
+        if (isAlreadyProcessed) {
+            throw new DailyChallengeException(DailyChallengeError.DAILY_CHALLENGE_ALREADY_PROCESSED);
+        }
     }
 
     public void changeStatusByCurrentStatus(DailyChallenge dailyChallenge) {

--- a/src/main/java/sopt/org/hmh/domain/point/service/PointFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/point/service/PointFacade.java
@@ -1,9 +1,7 @@
 package sopt.org.hmh.domain.point.service;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,7 +29,7 @@ public class PointFacade {
         DailyChallenge dailyChallenge = dailyChallengeService.findByChallengeDateAndUserIdOrThrowException(challengeDate, userId);
         User user = userService.findByIdOrThrowException(userId);
 
-        dailyChallengeService.validateDailyChallengeStatus(dailyChallenge, Status.NONE);
+        dailyChallengeService.validateDailyChallengeStatus(dailyChallenge.getStatus(), List.of(Status.NONE));
         dailyChallenge.changeStatus(Status.FAILURE);
 
         return new UsePointResponse(
@@ -44,7 +42,7 @@ public class PointFacade {
         DailyChallenge dailyChallenge = dailyChallengeService.findByChallengeDateAndUserIdOrThrowException(challengeDate, userId);
         User user = userService.findByIdOrThrowException(userId);
 
-        dailyChallengeService.validateDailyChallengeStatus(dailyChallenge, Status.UNEARNED);
+        dailyChallengeService.validateDailyChallengeStatus(dailyChallenge.getStatus(), List.of(Status.UNEARNED));
         dailyChallenge.changeStatus(Status.EARNED);
 
         return new EarnPointResponse(


### PR DESCRIPTION
<!--- 
❗️ check List 
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

❗️ 이슈 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
- deploy 배포 관련
-->

## Related issue 🚀
- closed #158 

## Work Description 💚
- ios의 요청으로 챌린지 성공 여부를 전송하는 api를 추가하였습니다.

## PR 참고 사항
- postman 테스트 완료했습니다!