### PR TITLE
feat: admin api 추가

### DIFF
--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminApi.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminApi.java
@@ -12,5 +12,5 @@ public interface AdminApi {
     ResponseEntity<BaseResponse<AdminTokenResponse>> orderAdminLogin(AdminLoginRequest request);
 
     @Operation(summary = "관리자 권한으로 유저 즉시 삭제")
-    ResponseEntity<?> orderAdminWithdrawImmediately(AdminUserIdRequest request);
+    ResponseEntity<Void> orderAdminWithdrawImmediately(AdminUserIdRequest request);
 }

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminApi.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminApi.java
@@ -3,9 +3,10 @@ package sopt.org.hmh.domain.admin.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import sopt.org.hmh.domain.admin.dto.request.AdminLoginRequest;
+import sopt.org.hmh.domain.admin.dto.response.AdminTokenResponse;
 import sopt.org.hmh.global.common.response.BaseResponse;
 
 public interface AdminApi {
     @Operation(summary = "소셜 로그인")
-    ResponseEntity<BaseResponse<?>> orderAdminLogin(AdminLoginRequest request);
+    ResponseEntity<BaseResponse<AdminTokenResponse>> orderAdminLogin(AdminLoginRequest request);
 }

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminApi.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminApi.java
@@ -3,6 +3,7 @@ package sopt.org.hmh.domain.admin.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import sopt.org.hmh.domain.admin.dto.request.AdminLoginRequest;
+import sopt.org.hmh.domain.admin.dto.request.AdminUserIdRequest;
 import sopt.org.hmh.domain.admin.dto.response.AdminTokenResponse;
 import sopt.org.hmh.global.common.response.BaseResponse;
 
@@ -11,5 +12,5 @@ public interface AdminApi {
     ResponseEntity<BaseResponse<AdminTokenResponse>> orderAdminLogin(AdminLoginRequest request);
 
     @Operation(summary = "관리자 권한으로 유저 즉시 삭제")
-    ResponseEntity<?> orderAdminWithdrawImmediately(Long userId);
+    ResponseEntity<?> orderAdminWithdrawImmediately(AdminUserIdRequest request);
 }

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminApi.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminApi.java
@@ -7,6 +7,9 @@ import sopt.org.hmh.domain.admin.dto.response.AdminTokenResponse;
 import sopt.org.hmh.global.common.response.BaseResponse;
 
 public interface AdminApi {
-    @Operation(summary = "소셜 로그인")
+    @Operation(summary = "관리자 로그인")
     ResponseEntity<BaseResponse<AdminTokenResponse>> orderAdminLogin(AdminLoginRequest request);
+
+    @Operation(summary = "관리자 권한으로 유저 즉시 삭제")
+    ResponseEntity<?> orderAdminWithdrawImmediately(Long userId);
 }

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminApi.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminApi.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import sopt.org.hmh.domain.admin.dto.request.AdminLoginRequest;
 import sopt.org.hmh.domain.admin.dto.request.AdminUserIdRequest;
+import sopt.org.hmh.domain.admin.dto.request.AdminUserInfoRequest;
 import sopt.org.hmh.domain.admin.dto.response.AdminTokenResponse;
 import sopt.org.hmh.global.common.response.BaseResponse;
 
@@ -13,4 +14,7 @@ public interface AdminApi {
 
     @Operation(summary = "관리자 권한으로 유저 즉시 삭제")
     ResponseEntity<Void> orderAdminWithdrawImmediately(AdminUserIdRequest request);
+
+    @Operation(summary = "관리자 권한으로 유저 정보 변경")
+    ResponseEntity<Void> orderAdminChangeUserInfo(AdminUserInfoRequest request);
 }

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminApi.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminApi.java
@@ -1,0 +1,11 @@
+package sopt.org.hmh.domain.admin.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import sopt.org.hmh.domain.admin.dto.request.AdminLoginRequest;
+import sopt.org.hmh.global.common.response.BaseResponse;
+
+public interface AdminApi {
+    @Operation(summary = "소셜 로그인")
+    ResponseEntity<BaseResponse<?>> orderAdminLogin(AdminLoginRequest request);
+}

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminApi.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminApi.java
@@ -2,6 +2,7 @@ package sopt.org.hmh.domain.admin.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
+import sopt.org.hmh.domain.admin.dto.request.AdminDailyChallengeRequest;
 import sopt.org.hmh.domain.admin.dto.request.AdminLoginRequest;
 import sopt.org.hmh.domain.admin.dto.request.AdminUserIdRequest;
 import sopt.org.hmh.domain.admin.dto.request.AdminUserInfoRequest;
@@ -17,4 +18,7 @@ public interface AdminApi {
 
     @Operation(summary = "관리자 권한으로 유저 정보 변경")
     ResponseEntity<Void> orderAdminChangeUserInfo(AdminUserInfoRequest request);
+
+    @Operation(summary = "관리자 권한으로 유저 챌린지 정보 변경")
+    ResponseEntity<Void> orderAdminChangeDailyChallengeInfo(AdminDailyChallengeRequest request);
 }

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
@@ -48,7 +48,7 @@ public class AdminController implements AdminApi {
     @PatchMapping("/user")
     public ResponseEntity<Void> orderAdminChangeUserInfo(
             @RequestBody @Valid final AdminUserInfoRequest request) {
-        adminFacade.ChangeUserInfo(request);
+        adminFacade.changeUserInfo(request);
         return ResponseEntity
                 .noContent()
                 .build();

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
@@ -1,0 +1,29 @@
+package sopt.org.hmh.domain.admin.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sopt.org.hmh.domain.admin.dto.request.AdminLoginRequest;
+import sopt.org.hmh.domain.admin.exception.AdminSuccess;
+import sopt.org.hmh.domain.admin.service.AdminFacade;
+import sopt.org.hmh.global.common.response.BaseResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin")
+public class AdminController implements AdminApi{
+    @Override
+    @PostMapping("/login")
+    public ResponseEntity<BaseResponse<?>> orderAdminLogin(
+            @RequestBody @Valid final AdminLoginRequest request)
+    {
+        return ResponseEntity
+                .status(AdminSuccess.ADMIN_LOGIN_SUCCESS.getHttpStatus())
+                .body(BaseResponse.success(AdminSuccess.ADMIN_LOGIN_SUCCESS, AdminFacade.adminLogin(request.authCode())));
+    }
+
+}

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
@@ -3,6 +3,7 @@ package sopt.org.hmh.domain.admin.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,11 +24,19 @@ public class AdminController implements AdminApi {
     @Override
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<AdminTokenResponse>> orderAdminLogin(
-            @RequestBody @Valid final AdminLoginRequest request) {
+            @RequestBody final AdminLoginRequest request) {
         return ResponseEntity
                 .status(AdminSuccess.ADMIN_LOGIN_SUCCESS.getHttpStatus())
                 .body(BaseResponse.success(AdminSuccess.ADMIN_LOGIN_SUCCESS,
                         adminFacade.adminLogin(request.authCode())));
     }
 
+    @Override
+    @DeleteMapping("/user")
+    public ResponseEntity<?> orderAdminWithdrawImmediately(@RequestBody @Valid final Long userId) {
+        adminFacade.withdrawImmediately(userId);
+        return ResponseEntity
+                .noContent()
+                .build();
+    }
 }

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
@@ -4,12 +4,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sopt.org.hmh.domain.admin.dto.request.AdminLoginRequest;
 import sopt.org.hmh.domain.admin.dto.request.AdminUserIdRequest;
+import sopt.org.hmh.domain.admin.dto.request.AdminUserInfoRequest;
 import sopt.org.hmh.domain.admin.dto.response.AdminTokenResponse;
 import sopt.org.hmh.domain.admin.exception.AdminSuccess;
 import sopt.org.hmh.domain.admin.service.AdminFacade;
@@ -37,6 +39,16 @@ public class AdminController implements AdminApi {
     public ResponseEntity<Void> orderAdminWithdrawImmediately(
             @RequestBody @Valid final AdminUserIdRequest request) {
         adminFacade.withdrawImmediately(request.userId());
+        return ResponseEntity
+                .noContent()
+                .build();
+    }
+
+    @Override
+    @PatchMapping("/user")
+    public ResponseEntity<Void> orderAdminChangeUserInfo(
+            @RequestBody @Valid final AdminUserInfoRequest request) {
+        adminFacade.ChangeUserInfo(request);
         return ResponseEntity
                 .noContent()
                 .build();

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sopt.org.hmh.domain.admin.dto.request.AdminLoginRequest;
+import sopt.org.hmh.domain.admin.dto.request.AdminUserIdRequest;
 import sopt.org.hmh.domain.admin.dto.response.AdminTokenResponse;
 import sopt.org.hmh.domain.admin.exception.AdminSuccess;
 import sopt.org.hmh.domain.admin.service.AdminFacade;
@@ -33,8 +34,9 @@ public class AdminController implements AdminApi {
 
     @Override
     @DeleteMapping("/user")
-    public ResponseEntity<?> orderAdminWithdrawImmediately(@RequestBody @Valid final Long userId) {
-        adminFacade.withdrawImmediately(userId);
+    public ResponseEntity<?> orderAdminWithdrawImmediately(
+            @RequestBody @Valid final AdminUserIdRequest request) {
+        adminFacade.withdrawImmediately(request.userId());
         return ResponseEntity
                 .noContent()
                 .build();

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
@@ -15,15 +15,18 @@ import sopt.org.hmh.global.common.response.BaseResponse;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin")
-public class AdminController implements AdminApi{
+public class AdminController implements AdminApi {
+
+    private final AdminFacade adminFacade;
+
     @Override
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<?>> orderAdminLogin(
-            @RequestBody @Valid final AdminLoginRequest request)
-    {
+            @RequestBody @Valid final AdminLoginRequest request) {
         return ResponseEntity
                 .status(AdminSuccess.ADMIN_LOGIN_SUCCESS.getHttpStatus())
-                .body(BaseResponse.success(AdminSuccess.ADMIN_LOGIN_SUCCESS, AdminFacade.adminLogin(request.authCode())));
+                .body(BaseResponse.success(AdminSuccess.ADMIN_LOGIN_SUCCESS,
+                        adminFacade.adminLogin(request.authCode())));
     }
 
 }

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sopt.org.hmh.domain.admin.dto.request.AdminLoginRequest;
+import sopt.org.hmh.domain.admin.dto.response.AdminTokenResponse;
 import sopt.org.hmh.domain.admin.exception.AdminSuccess;
 import sopt.org.hmh.domain.admin.service.AdminFacade;
 import sopt.org.hmh.global.common.response.BaseResponse;
@@ -21,7 +22,7 @@ public class AdminController implements AdminApi {
 
     @Override
     @PostMapping("/login")
-    public ResponseEntity<BaseResponse<?>> orderAdminLogin(
+    public ResponseEntity<BaseResponse<AdminTokenResponse>> orderAdminLogin(
             @RequestBody @Valid final AdminLoginRequest request) {
         return ResponseEntity
                 .status(AdminSuccess.ADMIN_LOGIN_SUCCESS.getHttpStatus())

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sopt.org.hmh.domain.admin.dto.request.AdminDailyChallengeRequest;
 import sopt.org.hmh.domain.admin.dto.request.AdminLoginRequest;
 import sopt.org.hmh.domain.admin.dto.request.AdminUserIdRequest;
 import sopt.org.hmh.domain.admin.dto.request.AdminUserInfoRequest;
@@ -49,6 +50,16 @@ public class AdminController implements AdminApi {
     public ResponseEntity<Void> orderAdminChangeUserInfo(
             @RequestBody @Valid final AdminUserInfoRequest request) {
         adminFacade.changeUserInfo(request);
+        return ResponseEntity
+                .noContent()
+                .build();
+    }
+
+    @Override
+    @PatchMapping("/challenge/daily")
+    public ResponseEntity<Void> orderAdminChangeDailyChallengeInfo(
+            @RequestBody @Valid final AdminDailyChallengeRequest request) {
+        adminFacade.changeDailyChallengeInfo(request);
         return ResponseEntity
                 .noContent()
                 .build();

--- a/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/controller/AdminController.java
@@ -34,7 +34,7 @@ public class AdminController implements AdminApi {
 
     @Override
     @DeleteMapping("/user")
-    public ResponseEntity<?> orderAdminWithdrawImmediately(
+    public ResponseEntity<Void> orderAdminWithdrawImmediately(
             @RequestBody @Valid final AdminUserIdRequest request) {
         adminFacade.withdrawImmediately(request.userId());
         return ResponseEntity

--- a/src/main/java/sopt/org/hmh/domain/admin/dto/request/AdminDailyChallengeRequest.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/dto/request/AdminDailyChallengeRequest.java
@@ -1,0 +1,12 @@
+package sopt.org.hmh.domain.admin.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+import sopt.org.hmh.domain.dailychallenge.domain.Status;
+
+public record AdminDailyChallengeRequest(
+        Long userId,
+        LocalDate startDate,
+        List<Status> statuses
+) {
+}

--- a/src/main/java/sopt/org/hmh/domain/admin/dto/request/AdminLoginRequest.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/dto/request/AdminLoginRequest.java
@@ -1,0 +1,7 @@
+package sopt.org.hmh.domain.admin.dto.request;
+
+public record AdminLoginRequest(
+        String authCode
+) {
+
+}

--- a/src/main/java/sopt/org/hmh/domain/admin/dto/request/AdminUserIdRequest.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/dto/request/AdminUserIdRequest.java
@@ -1,0 +1,7 @@
+package sopt.org.hmh.domain.admin.dto.request;
+
+public record AdminUserIdRequest(
+        Long userId
+) {
+
+}

--- a/src/main/java/sopt/org/hmh/domain/admin/dto/request/AdminUserInfoRequest.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/dto/request/AdminUserInfoRequest.java
@@ -1,0 +1,9 @@
+package sopt.org.hmh.domain.admin.dto.request;
+
+public record AdminUserInfoRequest(
+        Long userId,
+        String name,
+        Integer point
+) {
+
+}

--- a/src/main/java/sopt/org/hmh/domain/admin/dto/response/AdminTokenResponse.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/dto/response/AdminTokenResponse.java
@@ -1,0 +1,6 @@
+package sopt.org.hmh.domain.admin.dto.response;
+
+public record AdminTokenResponse(
+        String accessToken
+) {
+}

--- a/src/main/java/sopt/org/hmh/domain/admin/exception/AdminError.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/exception/AdminError.java
@@ -8,7 +8,7 @@ import sopt.org.hmh.global.common.exception.base.ErrorBase;
 public enum AdminError implements ErrorBase {
 
     // 401 UNAUTHORIZED
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    INVALID_ADMIN_AUTH_CODE(HttpStatus.UNAUTHORIZED, "관리자 인증 번호가 일치하지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/sopt/org/hmh/domain/admin/exception/AdminError.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/exception/AdminError.java
@@ -1,0 +1,31 @@
+package sopt.org.hmh.domain.admin.exception;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import sopt.org.hmh.global.common.exception.base.ErrorBase;
+
+@AllArgsConstructor
+public enum AdminError implements ErrorBase {
+
+    // 401 UNAUTHORIZED
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String errorMessage;
+
+    @Override
+    public int getHttpStatusCode() {
+        return this.status.value();
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getErrorMessage() {
+        return this.errorMessage;
+    }
+}

--- a/src/main/java/sopt/org/hmh/domain/admin/exception/AdminException.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/exception/AdminException.java
@@ -1,0 +1,11 @@
+package sopt.org.hmh.domain.admin.exception;
+
+import sopt.org.hmh.domain.auth.exception.AuthError;
+import sopt.org.hmh.global.common.exception.base.ExceptionBase;
+
+public class AdminException extends ExceptionBase {
+
+    public AdminException(AuthError errorBase) {
+        super(errorBase);
+    }
+}

--- a/src/main/java/sopt/org/hmh/domain/admin/exception/AdminException.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/exception/AdminException.java
@@ -1,11 +1,10 @@
 package sopt.org.hmh.domain.admin.exception;
 
-import sopt.org.hmh.domain.auth.exception.AuthError;
 import sopt.org.hmh.global.common.exception.base.ExceptionBase;
 
 public class AdminException extends ExceptionBase {
 
-    public AdminException(AuthError errorBase) {
+    public AdminException(AdminError errorBase) {
         super(errorBase);
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/admin/exception/AdminSuccess.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/exception/AdminSuccess.java
@@ -9,6 +9,9 @@ public enum AdminSuccess implements SuccessBase {
 
     // 200 OK
     ADMIN_LOGIN_SUCCESS(HttpStatus.OK, "관리자 로그인에 성공했습니다."),
+
+    // 204 NO CONTENT
+    ADMIN_WITHDRAW_IMMEDIATELY_SUCCESS(HttpStatus.NO_CONTENT, "관리자 권한으로 유저 즉시 삭제에 성공했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/sopt/org/hmh/domain/admin/exception/AdminSuccess.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/exception/AdminSuccess.java
@@ -1,0 +1,31 @@
+package sopt.org.hmh.domain.admin.exception;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import sopt.org.hmh.global.common.exception.base.SuccessBase;
+
+@AllArgsConstructor
+public enum AdminSuccess implements SuccessBase {
+
+    // 200 OK
+    ADMIN_LOGIN_SUCCESS(HttpStatus.OK, "관리자 로그인에 성공했습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String successMessage;
+
+    @Override
+    public int getHttpStatusCode() {
+        return this.status.value();
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getSuccessMessage() {
+        return this.successMessage;
+    }
+}

--- a/src/main/java/sopt/org/hmh/domain/admin/service/AdminFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/service/AdminFacade.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import sopt.org.hmh.domain.admin.dto.response.AdminTokenResponse;
 import sopt.org.hmh.domain.admin.exception.AdminError;
 import sopt.org.hmh.domain.admin.exception.AdminException;
+import sopt.org.hmh.domain.user.service.UserService;
 import sopt.org.hmh.global.auth.jwt.TokenService;
 
 @Service
@@ -15,6 +16,7 @@ public class AdminFacade {
     @Value("${jwt.admin-auth-code}")
     private String adminAuthCode;
 
+    private final UserService userService;
     private final TokenService tokenService;
 
     public AdminTokenResponse adminLogin(String authCode) {
@@ -26,5 +28,9 @@ public class AdminFacade {
         if (!adminAuthCode.equals(authCode)) {
             throw new AdminException(AdminError.INVALID_ADMIN_AUTH_CODE);
         }
+    }
+
+    public void withdrawImmediately(Long userId) {
+        userService.withdrawImmediately(userId);
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/admin/service/AdminFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/service/AdminFacade.java
@@ -1,14 +1,22 @@
 package sopt.org.hmh.domain.admin.service;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sopt.org.hmh.domain.admin.dto.request.AdminDailyChallengeRequest;
 import sopt.org.hmh.domain.admin.dto.request.AdminUserInfoRequest;
 import sopt.org.hmh.domain.admin.dto.response.AdminTokenResponse;
 import sopt.org.hmh.domain.admin.exception.AdminError;
 import sopt.org.hmh.domain.admin.exception.AdminException;
+import sopt.org.hmh.domain.challenge.domain.exception.ChallengeError;
+import sopt.org.hmh.domain.challenge.domain.exception.ChallengeException;
+import sopt.org.hmh.domain.challenge.service.ChallengeService;
+import sopt.org.hmh.domain.dailychallenge.domain.Status;
+import sopt.org.hmh.domain.dailychallenge.service.DailyChallengeService;
 import sopt.org.hmh.domain.user.domain.User;
 import sopt.org.hmh.domain.user.service.UserService;
 import sopt.org.hmh.global.auth.jwt.TokenService;
@@ -22,6 +30,8 @@ public class AdminFacade {
 
     private final UserService userService;
     private final TokenService tokenService;
+    private final ChallengeService challengeService;
+    private final DailyChallengeService dailyChallengeService;
 
     public AdminTokenResponse adminLogin(String authCode) {
         validateAdminAuthCode(authCode);
@@ -48,6 +58,23 @@ public class AdminFacade {
         }
         if (Objects.nonNull(request.name())) {
             user.changeName(request.name());
+        }
+    }
+
+    @Transactional
+    public void changeDailyChallengeInfo(AdminDailyChallengeRequest request) {
+        Long currentChallengeId = userService.getCurrentChallengeIdByUserId(request.userId());
+        List<Status> statuses = request.statuses();
+        LocalDate challengeDate = request.startDate();
+
+        validateStatusesPeriod(currentChallengeId, statuses);
+        dailyChallengeService.changeInfoOfDailyChallenges(currentChallengeId, statuses, challengeDate);
+    }
+
+    private void validateStatusesPeriod(Long challengeId, List<Status> statuses) {
+        Integer challengePeriod = challengeService.getChallengePeriod(challengeId);
+        if (challengePeriod != statuses.size()) {
+            throw new ChallengeException(ChallengeError.INVALID_PERIOD_NUMERIC);
         }
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/admin/service/AdminFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/service/AdminFacade.java
@@ -1,0 +1,30 @@
+package sopt.org.hmh.domain.admin.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import sopt.org.hmh.domain.admin.dto.response.AdminTokenResponse;
+import sopt.org.hmh.domain.admin.exception.AdminError;
+import sopt.org.hmh.domain.admin.exception.AdminException;
+import sopt.org.hmh.global.auth.jwt.TokenService;
+
+@Service
+@RequiredArgsConstructor
+public class AdminFacade {
+
+    @Value("${jwt.admin-auth-code}")
+    private String adminAuthCode;
+
+    private final TokenService tokenService;
+
+    public AdminTokenResponse adminLogin(String authCode) {
+        validateAdminAuthCode(authCode);
+        return new AdminTokenResponse(tokenService.issueAdminToken());
+    }
+
+    private void validateAdminAuthCode(String authCode) {
+        if (!adminAuthCode.equals(authCode)) {
+            throw new AdminException(AdminError.INVALID_ADMIN_AUTH_CODE);
+        }
+    }
+}

--- a/src/main/java/sopt/org/hmh/domain/admin/service/AdminFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/service/AdminFacade.java
@@ -1,12 +1,15 @@
 package sopt.org.hmh.domain.admin.service;
 
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sopt.org.hmh.domain.admin.dto.request.AdminUserInfoRequest;
 import sopt.org.hmh.domain.admin.dto.response.AdminTokenResponse;
 import sopt.org.hmh.domain.admin.exception.AdminError;
 import sopt.org.hmh.domain.admin.exception.AdminException;
+import sopt.org.hmh.domain.user.domain.User;
 import sopt.org.hmh.domain.user.service.UserService;
 import sopt.org.hmh.global.auth.jwt.TokenService;
 
@@ -35,5 +38,16 @@ public class AdminFacade {
     public void withdrawImmediately(Long userId) {
         userService.checkIsExistUserId(userId);
         userService.withdrawImmediately(userId);
+    }
+
+    @Transactional
+    public void changeUserInfo(AdminUserInfoRequest request) {
+        User user = userService.findByIdOrThrowException(request.userId());
+        if (Objects.nonNull(request.point())) {
+            user.changePoint(request.point());
+        }
+        if (Objects.nonNull(request.name())) {
+            user.changeName(request.name());
+        }
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/admin/service/AdminFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/service/AdminFacade.java
@@ -3,6 +3,7 @@ package sopt.org.hmh.domain.admin.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import sopt.org.hmh.domain.admin.dto.response.AdminTokenResponse;
 import sopt.org.hmh.domain.admin.exception.AdminError;
 import sopt.org.hmh.domain.admin.exception.AdminException;
@@ -30,7 +31,9 @@ public class AdminFacade {
         }
     }
 
+    @Transactional
     public void withdrawImmediately(Long userId) {
+        userService.checkIsExistUserId(userId);
         userService.withdrawImmediately(userId);
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/admin/service/AdminFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/admin/service/AdminFacade.java
@@ -47,6 +47,7 @@ public class AdminFacade {
     @Transactional
     public void withdrawImmediately(Long userId) {
         userService.checkIsExistUserId(userId);
+        challengeService.deleteChallengeRelatedByUserId(userId);
         userService.withdrawImmediately(userId);
     }
 

--- a/src/main/java/sopt/org/hmh/domain/auth/service/AuthFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/auth/service/AuthFacade.java
@@ -73,7 +73,7 @@ public class AuthFacade {
             kakaoLoginService.updateUserInfoByKakao(loginUser, socialAccessToken);
         }
         Long userId = loginUser.getId();
-        return new LoginResponse(userId, tokenService.issueToken(userId));
+        return new LoginResponse(userId, tokenService.issueToken(userId.toString()));
     }
 
     public SocialAccessTokenResponse getSocialAccessTokenByAuthorizationCode(String code) {

--- a/src/main/java/sopt/org/hmh/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/controller/ChallengeController.java
@@ -25,9 +25,10 @@ public class ChallengeController implements ChallengeApi {
 
     @PostMapping
     @Override
-    public ResponseEntity<BaseResponse<?>> orderAddChallenge(@UserId final Long userId,
-                                                             @RequestHeader("OS") final String os,
-                                                             @RequestBody @Valid final ChallengeRequest request) {
+    public ResponseEntity<BaseResponse<?>> orderAddChallenge(
+            @UserId final Long userId,
+            @RequestHeader("OS") final String os,
+            @RequestBody @Valid final ChallengeRequest request) {
         challengeFacade.addChallenge(userId, request, os);
 
         return ResponseEntity
@@ -37,8 +38,9 @@ public class ChallengeController implements ChallengeApi {
 
     @GetMapping
     @Override
-    public ResponseEntity<BaseResponse<ChallengeResponse>> orderGetChallenge(@UserId final Long userId,
-                                                                             @RequestHeader("OS") final String os) {
+    public ResponseEntity<BaseResponse<ChallengeResponse>> orderGetChallenge(
+            @UserId final Long userId,
+            @RequestHeader("OS") final String os) {
         return ResponseEntity
                 .status(ChallengeSuccess.GET_CHALLENGE_SUCCESS.getHttpStatus())
                 .body(BaseResponse.success(ChallengeSuccess.GET_CHALLENGE_SUCCESS,
@@ -47,8 +49,9 @@ public class ChallengeController implements ChallengeApi {
 
     @GetMapping("/home")
     @Override
-    public ResponseEntity<BaseResponse<DailyChallengeResponse>> orderGetDailyChallenge(@UserId final Long userId,
-                                                                                       @RequestHeader("OS") final String os) {
+    public ResponseEntity<BaseResponse<DailyChallengeResponse>> orderGetDailyChallenge(
+            @UserId final Long userId,
+            @RequestHeader("OS") final String os) {
         return ResponseEntity
                 .status(ChallengeSuccess.GET_DAILY_CHALLENGE_SUCCESS.getHttpStatus())
                 .body(BaseResponse.success(ChallengeSuccess.GET_DAILY_CHALLENGE_SUCCESS,
@@ -57,9 +60,10 @@ public class ChallengeController implements ChallengeApi {
 
     @PostMapping("/app")
     @Override
-    public ResponseEntity<BaseResponse<?>> orderAddApps(@UserId final Long userId,
-                                                        @RequestHeader("OS") final String os,
-                                                        @RequestBody @Valid final ChallengeAppArrayRequest requests) {
+    public ResponseEntity<BaseResponse<?>> orderAddApps(
+            @UserId final Long userId,
+            @RequestHeader("OS") final String os,
+            @RequestBody @Valid final ChallengeAppArrayRequest requests) {
         challengeFacade.addAppsToCurrentChallenge(userId, requests.apps(), os);
 
         return ResponseEntity
@@ -70,9 +74,10 @@ public class ChallengeController implements ChallengeApi {
 
     @DeleteMapping("/app")
     @Override
-    public ResponseEntity<BaseResponse<?>> orderRemoveApp(@UserId final Long userId,
-                                                          @RequestHeader("OS") final String os,
-                                                          @RequestBody @Valid final AppRemoveRequest request) {
+    public ResponseEntity<BaseResponse<?>> orderRemoveApp(
+            @UserId final Long userId,
+            @RequestHeader("OS") final String os,
+            @RequestBody @Valid final AppRemoveRequest request) {
         challengeFacade.removeAppFromCurrentChallenge(userId, request.appCode(), os);
 
         return ResponseEntity

--- a/src/main/java/sopt/org/hmh/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/repository/ChallengeRepository.java
@@ -10,4 +10,6 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     Optional<Challenge> findById(Long id);
 
     void deleteByUserIdIn(List<Long> userId);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
@@ -31,4 +31,8 @@ public class ChallengeService {
     public Challenge save(Challenge challenge) {
         return challengeRepository.save(challenge);
     }
+
+    public Integer getChallengePeriod(Long challengeId) {
+        return findByIdOrElseThrow(challengeId).getPeriod();
+    }
 }

--- a/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeService.java
@@ -15,8 +15,12 @@ public class ChallengeService {
 
     private final ChallengeRepository challengeRepository;
 
-    public void deleteChallengeRelatedByUserId(List<Long> expiredUserIdList) {
+    public void deleteChallengeRelatedByUserIds(List<Long> expiredUserIdList) {
         challengeRepository.deleteByUserIdIn(expiredUserIdList);
+    }
+
+    public void deleteChallengeRelatedByUserId(Long userId) {
+        challengeRepository.deleteByUserId(userId);
     }
 
     public Challenge findByIdOrElseThrow(Long challengeId) {

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/DailyChallenge.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/DailyChallenge.java
@@ -9,7 +9,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.Assert;
 import sopt.org.hmh.domain.app.domain.HistoryApp;
 import sopt.org.hmh.global.common.domain.BaseTimeEntity;
 import sopt.org.hmh.domain.challenge.domain.Challenge;
@@ -52,6 +51,10 @@ public class DailyChallenge extends BaseTimeEntity {
         this.goalTime = goalTime;
         this.challengeDate = challengeDate;
         this.status = Status.NONE;
+    }
+
+    public void changeChallengeDate(LocalDate challengeDate) {
+        this.challengeDate = challengeDate;
     }
 
     public void changeStatus(Status status) {

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/repository/DailyChallengeRepository.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/repository/DailyChallengeRepository.java
@@ -1,10 +1,14 @@
 package sopt.org.hmh.domain.dailychallenge.repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sopt.org.hmh.domain.dailychallenge.domain.DailyChallenge;
 
 public interface DailyChallengeRepository extends JpaRepository<DailyChallenge, Long> {
+
     Optional<DailyChallenge> findByChallengeDateAndUserId(LocalDate challengeDate, Long userId);
+
+    List<DailyChallenge> findAllByChallengeId(Long challengeId);
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
@@ -25,10 +25,12 @@ public class DailyChallengeFacade {
     @Transactional
     public void addFinishedDailyChallengeHistory(Long userId, FinishedDailyChallengeListRequest requests, String os) {
         Long currentChallengeId = userService.getCurrentChallengeIdByUserId(userId);
-        List<ChallengeApp> currentChallengeApps = challengeService.getCurrentChallengeAppByChallengeId(currentChallengeId);
+        List<ChallengeApp> currentChallengeApps =
+                challengeService.getCurrentChallengeAppByChallengeId(currentChallengeId);
 
         requests.finishedDailyChallenges().forEach(request -> {
-            DailyChallenge dailyChallenge = dailyChallengeService.findByChallengeDateAndUserIdOrThrowException(request.challengeDate(), userId);
+            DailyChallenge dailyChallenge =
+                    dailyChallengeService.findByChallengeDateAndUserIdOrThrowException(request.challengeDate(), userId);
             dailyChallengeService.changeStatusByCurrentStatus(dailyChallenge);
             historyAppService.addHistoryApp(currentChallengeApps, request.apps(), dailyChallenge, os);
         });
@@ -37,12 +39,14 @@ public class DailyChallengeFacade {
     @Transactional
     public void changeDailyChallengeStatusByIsSuccess(Long userId, FinishedDailyChallengeStatusListRequest requests) {
         requests.finishedDailyChallenges().forEach(request -> {
-            DailyChallenge dailyChallenge = dailyChallengeService.findByChallengeDateAndUserIdOrThrowException(request.challengeDate(), userId);
+            DailyChallenge dailyChallenge =
+                    dailyChallengeService.findByChallengeDateAndUserIdOrThrowException(request.challengeDate(), userId);
             if (request.isSuccess()) {
                 dailyChallengeService.validateDailyChallengeStatus(dailyChallenge.getStatus(), List.of(Status.NONE));
                 dailyChallenge.changeStatus(Status.UNEARNED);
             } else {
-                dailyChallengeService.validateDailyChallengeStatus(dailyChallenge.getStatus(), List.of(Status.NONE, Status.FAILURE));
+                dailyChallengeService.validateDailyChallengeStatus(
+                        dailyChallenge.getStatus(), List.of(Status.NONE, Status.FAILURE));
                 dailyChallenge.changeStatus(Status.FAILURE);
             }
         });

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
@@ -65,15 +65,13 @@ public class DailyChallengeService {
     }
 
     private void changeStatusOfDailyChallenges(List<DailyChallenge> dailyChallenges, List<Status> statuses) {
-        int challengePeriod = dailyChallenges.size();
-        for (int i = 0; i < challengePeriod; i++) {
+        for (int i = 0; i < dailyChallenges.size(); i++) {
             dailyChallenges.get(i).changeStatus(statuses.get(i));
         }
     }
 
     private void changeChallengeDateOfDailyChallenges(List<DailyChallenge> dailyChallenges, LocalDate challengeDate) {
-        int challengePeriod = dailyChallenges.size();
-        for (int i = 0; i < challengePeriod; i++) {
+        for (int i = 0; i < dailyChallenges.size(); i++) {
             dailyChallenges.get(i).changeChallengeDate(challengeDate.plusDays(i));
         }
     }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
@@ -53,4 +53,28 @@ public class DailyChallengeService {
                         .goalTime(challenge.getGoalTime()).build())
                 .toList());
     }
+
+    public List<DailyChallenge> getDailyChallengesByChallengeId(Long challengeId) {
+        return dailyChallengeRepository.findAllByChallengeId(challengeId);
+    }
+
+    public void changeInfoOfDailyChallenges(Long challengeId, List<Status> statuses, LocalDate challengeDate) {
+        List<DailyChallenge> dailyChallenges = getDailyChallengesByChallengeId(challengeId);
+        changeStatusOfDailyChallenges(dailyChallenges, statuses);
+        changeChallengeDateOfDailyChallenges(dailyChallenges, challengeDate);
+    }
+
+    private void changeStatusOfDailyChallenges(List<DailyChallenge> dailyChallenges, List<Status> statuses) {
+        int challengePeriod = dailyChallenges.size();
+        for (int i = 0; i < challengePeriod; i++) {
+            dailyChallenges.get(i).changeStatus(statuses.get(i));
+        }
+    }
+
+    private void changeChallengeDateOfDailyChallenges(List<DailyChallenge> dailyChallenges, LocalDate challengeDate) {
+        int challengePeriod = dailyChallenges.size();
+        for (int i = 0; i < challengePeriod; i++) {
+            dailyChallenges.get(i).changeChallengeDate(challengeDate.plusDays(i));
+        }
+    }
 }

--- a/src/main/java/sopt/org/hmh/domain/user/domain/User.java
+++ b/src/main/java/sopt/org/hmh/domain/user/domain/User.java
@@ -89,6 +89,14 @@ public class User extends BaseTimeEntity {
         return this.point;
     }
 
+    public void changePoint(Integer point) {
+        this.point = point;
+    }
+
+    public void changeName(String name) {
+        this.name = name;
+    }
+
     public void changeCurrentChallengeId(Long currentChallengeId) {
         this.currentChallengeId = currentChallengeId;
     }

--- a/src/main/java/sopt/org/hmh/domain/user/service/ExpiredUserDeleteScheduler.java
+++ b/src/main/java/sopt/org/hmh/domain/user/service/ExpiredUserDeleteScheduler.java
@@ -25,6 +25,6 @@ public class ExpiredUserDeleteScheduler {
     public void deleteExpiredUser(LocalDateTime currentDate) {
         List<Long> expiredUserList = userRepository.findIdByDeletedAtBeforeAndIsDeletedIsTrue(currentDate);
         userRepository.deleteAllById(expiredUserList);
-        challengeService.deleteChallengeRelatedByUserId(expiredUserList);
+        challengeService.deleteChallengeRelatedByUserIds(expiredUserList);
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/user/service/UserService.java
+++ b/src/main/java/sopt/org/hmh/domain/user/service/UserService.java
@@ -90,7 +90,7 @@ public class UserService {
     }
 
     public void checkIsExistUserId(Long userId) {
-        if (isExistUserId(userId)) {
+        if (!isExistUserId(userId)) {
             throw new UserException(UserError.NOT_FOUND_USER);
         }
     }

--- a/src/main/java/sopt/org/hmh/domain/user/service/UserService.java
+++ b/src/main/java/sopt/org/hmh/domain/user/service/UserService.java
@@ -85,6 +85,16 @@ public class UserService {
                 () -> new UserException(UserError.NOT_FOUND_USER));
     }
 
+    private boolean isExistUserId(Long userId) {
+        return userRepository.existsById(userId);
+    }
+
+    public void checkIsExistUserId(Long userId) {
+        if (isExistUserId(userId)) {
+            throw new UserException(UserError.NOT_FOUND_USER);
+        }
+    }
+
     public Long getCurrentChallengeIdByUserId(Long userId) {
         return Optional.ofNullable(this.findByIdOrThrowException(userId).getCurrentChallengeId())
                 .orElseThrow(() -> new UserException(UserError.NOT_FOUND_CURRENT_CHALLENGE_ID));
@@ -101,7 +111,6 @@ public class UserService {
         return new IsLockTodayResponse(lockCheckDate.equals(userRecentLockDate));
     }
 
-    @Transactional
     public void withdrawImmediately(Long userId) {
         userRepository.deleteById(userId);
     }

--- a/src/main/java/sopt/org/hmh/domain/user/service/UserService.java
+++ b/src/main/java/sopt/org/hmh/domain/user/service/UserService.java
@@ -100,4 +100,9 @@ public class UserService {
         LocalDate userRecentLockDate = this.findByIdOrThrowException(userId).getRecentLockDate();
         return new IsLockTodayResponse(lockCheckDate.equals(userRecentLockDate));
     }
+
+    @Transactional
+    public void withdrawImmediately(Long userId) {
+        userRepository.deleteById(userId);
+    }
 }

--- a/src/main/java/sopt/org/hmh/global/auth/UserIdArgumentResolver.java
+++ b/src/main/java/sopt/org/hmh/global/auth/UserIdArgumentResolver.java
@@ -21,9 +21,11 @@ public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
-        return SecurityContextHolder.getContext()
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        return Long.parseLong(SecurityContextHolder.getContext()
                 .getAuthentication()
-                .getPrincipal();
+                .getPrincipal()
+                .toString());
     }
 }

--- a/src/main/java/sopt/org/hmh/global/auth/jwt/JwtConstants.java
+++ b/src/main/java/sopt/org/hmh/global/auth/jwt/JwtConstants.java
@@ -8,4 +8,5 @@ public abstract class JwtConstants {
     public static final String AUTHORIZATION = "Authorization";
     public static final String BEARER = "Bearer ";
     public static final String CHARACTER_ENCODING = "UTF-8";
+    public static final String ADMIN_ROLE = "ADMIN";
 }

--- a/src/main/java/sopt/org/hmh/global/auth/jwt/JwtGenerator.java
+++ b/src/main/java/sopt/org/hmh/global/auth/jwt/JwtGenerator.java
@@ -22,6 +22,8 @@ public class JwtGenerator {
     private Long ACCESS_TOKEN_EXPIRATION_TIME;
     @Value("${jwt.refresh-token-expiration-time}")
     private Long REFRESH_TOKEN_EXPIRATION_TIME;
+    @Value("${jwt.admin-access-token-expiration-time}")
+    private Long ADMIN_ACCESS_TOKEN_EXPIRATION_TIME;
 
     public String generateToken(Long userId, boolean isRefreshToken) {
         final Date now = generateNowDate();
@@ -32,6 +34,18 @@ public class JwtGenerator {
                 .setSubject(String.valueOf(userId))
                 .setIssuedAt(now)
                 .setExpiration(expiration)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    public String generateAdminToken() {
+        final Date now = generateNowDate();
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setSubject("ADMIN")
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ADMIN_ACCESS_TOKEN_EXPIRATION_TIME))
                 .signWith(getSigningKey())
                 .compact();
     }

--- a/src/main/java/sopt/org/hmh/global/auth/jwt/JwtGenerator.java
+++ b/src/main/java/sopt/org/hmh/global/auth/jwt/JwtGenerator.java
@@ -1,5 +1,7 @@
 package sopt.org.hmh.global.auth.jwt;
 
+import static sopt.org.hmh.global.auth.jwt.JwtConstants.ADMIN_ROLE;
+
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
@@ -43,7 +45,7 @@ public class JwtGenerator {
 
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-                .setSubject("ADMIN")
+                .setSubject(ADMIN_ROLE)
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + ADMIN_ACCESS_TOKEN_EXPIRATION_TIME))
                 .signWith(getSigningKey())

--- a/src/main/java/sopt/org/hmh/global/auth/jwt/JwtGenerator.java
+++ b/src/main/java/sopt/org/hmh/global/auth/jwt/JwtGenerator.java
@@ -27,13 +27,13 @@ public class JwtGenerator {
     @Value("${jwt.admin-access-token-expiration-time}")
     private Long ADMIN_ACCESS_TOKEN_EXPIRATION_TIME;
 
-    public String generateToken(Long userId, boolean isRefreshToken) {
+    public String generateToken(String subjectId, boolean isRefreshToken) {
         final Date now = generateNowDate();
         final Date expiration = generateExpirationDate(isRefreshToken, now);
 
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-                .setSubject(String.valueOf(userId))
+                .setSubject(subjectId)
                 .setIssuedAt(now)
                 .setExpiration(expiration)
                 .signWith(getSigningKey())

--- a/src/main/java/sopt/org/hmh/global/auth/jwt/JwtPrefixExtractor.java
+++ b/src/main/java/sopt/org/hmh/global/auth/jwt/JwtPrefixExtractor.java
@@ -1,0 +1,19 @@
+package sopt.org.hmh.global.auth.jwt;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+import sopt.org.hmh.global.auth.jwt.exception.JwtError;
+import sopt.org.hmh.global.auth.jwt.exception.JwtException;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class JwtPrefixExtractor {
+
+    public static String extractPrefix(String accessToken) {
+        if (StringUtils.hasText(accessToken) && accessToken.startsWith(JwtConstants.BEARER)) {
+            return accessToken.substring(JwtConstants.BEARER.length());
+        }
+        throw new JwtException(JwtError.INVALID_ACCESS_TOKEN);
+    }
+
+}

--- a/src/main/java/sopt/org/hmh/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/sopt/org/hmh/global/auth/jwt/JwtProvider.java
@@ -10,16 +10,16 @@ public class JwtProvider {
 
     private final JwtGenerator jwtGenerator;
 
-    public TokenResponse issueToken(Long userId) {
-        return new TokenResponse(jwtGenerator.generateToken(userId, false),
-                jwtGenerator.generateToken(userId, true));
+    public TokenResponse issueToken(String subjectId) {
+        return new TokenResponse(jwtGenerator.generateToken(subjectId, false),
+                jwtGenerator.generateToken(subjectId, true));
     }
 
-    public Long getSubject(String token) {
+    public String getSubject(String token) {
         JwtParser jwtParser = jwtGenerator.getJwtParser();
-        return Long.valueOf(jwtParser.parseClaimsJws(token)
+        return jwtParser.parseClaimsJws(token)
                 .getBody()
-                .getSubject());
+                .getSubject();
     }
 
     public String issueAdminToken() {

--- a/src/main/java/sopt/org/hmh/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/sopt/org/hmh/global/auth/jwt/JwtProvider.java
@@ -1,5 +1,7 @@
 package sopt.org.hmh.global.auth.jwt;
 
+import static sopt.org.hmh.global.auth.jwt.JwtPrefixExtractor.extractPrefix;
+
 import io.jsonwebtoken.JwtParser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -16,8 +18,9 @@ public class JwtProvider {
     }
 
     public String getSubject(String token) {
+        String extractedToken = extractPrefix(token);
         JwtParser jwtParser = jwtGenerator.getJwtParser();
-        return jwtParser.parseClaimsJws(token)
+        return jwtParser.parseClaimsJws(extractedToken)
                 .getBody()
                 .getSubject();
     }

--- a/src/main/java/sopt/org/hmh/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/sopt/org/hmh/global/auth/jwt/JwtProvider.java
@@ -21,4 +21,8 @@ public class JwtProvider {
                 .getBody()
                 .getSubject());
     }
+
+    public String issueAdminToken() {
+        return jwtGenerator.generateAdminToken();
+    }
 }

--- a/src/main/java/sopt/org/hmh/global/auth/jwt/JwtValidator.java
+++ b/src/main/java/sopt/org/hmh/global/auth/jwt/JwtValidator.java
@@ -1,6 +1,10 @@
 package sopt.org.hmh.global.auth.jwt;
 
+import static sopt.org.hmh.global.auth.jwt.JwtConstants.ADMIN_ROLE;
+
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtParser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -32,8 +36,15 @@ public class JwtValidator {
         }
     }
 
-    private void parseToken(String token) {
+    private Jws<Claims> parseToken(String token) {
         JwtParser jwtParser = jwtGenerator.getJwtParser();
-        jwtParser.parseClaimsJws(token);
+        return jwtParser.parseClaimsJws(token);
+    }
+
+    public void validateAdminToken(String token) {
+        String subject = parseToken(token).getBody().getSubject();
+        if (!subject.equals(ADMIN_ROLE)) {
+            throw new JwtException(JwtError.INVALID_ADMIN_TOKEN);
+        }
     }
 }

--- a/src/main/java/sopt/org/hmh/global/auth/jwt/JwtValidator.java
+++ b/src/main/java/sopt/org/hmh/global/auth/jwt/JwtValidator.java
@@ -1,6 +1,7 @@
 package sopt.org.hmh.global.auth.jwt;
 
 import static sopt.org.hmh.global.auth.jwt.JwtConstants.ADMIN_ROLE;
+import static sopt.org.hmh.global.auth.jwt.JwtPrefixExtractor.extractPrefix;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -37,8 +38,9 @@ public class JwtValidator {
     }
 
     private Jws<Claims> parseToken(String token) {
+        String extractedToken = extractPrefix(token);
         JwtParser jwtParser = jwtGenerator.getJwtParser();
-        return jwtParser.parseClaimsJws(token);
+        return jwtParser.parseClaimsJws(extractedToken);
     }
 
     public void validateAdminToken(String token) {

--- a/src/main/java/sopt/org/hmh/global/auth/jwt/TokenService.java
+++ b/src/main/java/sopt/org/hmh/global/auth/jwt/TokenService.java
@@ -1,11 +1,11 @@
 package sopt.org.hmh.global.auth.jwt;
 
+import static sopt.org.hmh.global.auth.jwt.JwtPrefixExtractor.extractPrefix;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sopt.org.hmh.domain.auth.dto.response.ReissueResponse;
-import sopt.org.hmh.global.auth.jwt.exception.JwtError;
-import sopt.org.hmh.global.auth.jwt.exception.JwtException;
 
 @Service
 @RequiredArgsConstructor
@@ -16,18 +16,10 @@ public class TokenService {
 
     @Transactional
     public ReissueResponse reissueToken(String refreshToken) {
-        String parsedRefreshToken = parseTokenString(refreshToken);
+        String parsedRefreshToken = extractPrefix(refreshToken);
         String userId = jwtProvider.getSubject(parsedRefreshToken);
         jwtValidator.validateRefreshToken(parsedRefreshToken);
         return ReissueResponse.of(jwtProvider.issueToken(userId));
-    }
-
-    private String parseTokenString(String tokenString) {
-        String[] parsedTokens = tokenString.split(" ");
-        if (parsedTokens.length != 2) {
-            throw new JwtException(JwtError.INVALID_TOKEN_HEADER);
-        }
-        return parsedTokens[1];
     }
 
     public TokenResponse issueToken(String subjectId) {
@@ -36,6 +28,10 @@ public class TokenService {
 
     public String issueAdminToken() {
         return jwtProvider.issueAdminToken();
+    }
+
+    public void validateAdminToken(String token){
+        jwtValidator.validateAdminToken(token);
     }
 
 }

--- a/src/main/java/sopt/org/hmh/global/auth/jwt/TokenService.java
+++ b/src/main/java/sopt/org/hmh/global/auth/jwt/TokenService.java
@@ -17,7 +17,7 @@ public class TokenService {
     @Transactional
     public ReissueResponse reissueToken(String refreshToken) {
         String parsedRefreshToken = parseTokenString(refreshToken);
-        Long userId = jwtProvider.getSubject(parsedRefreshToken);
+        String userId = jwtProvider.getSubject(parsedRefreshToken);
         jwtValidator.validateRefreshToken(parsedRefreshToken);
         return ReissueResponse.of(jwtProvider.issueToken(userId));
     }
@@ -30,8 +30,8 @@ public class TokenService {
         return parsedTokens[1];
     }
 
-    public TokenResponse issueToken(Long userId) {
-        return jwtProvider.issueToken(userId);
+    public TokenResponse issueToken(String subjectId) {
+        return jwtProvider.issueToken(subjectId);
     }
 
     public String issueAdminToken() {

--- a/src/main/java/sopt/org/hmh/global/auth/jwt/TokenService.java
+++ b/src/main/java/sopt/org/hmh/global/auth/jwt/TokenService.java
@@ -34,4 +34,8 @@ public class TokenService {
         return jwtProvider.issueToken(userId);
     }
 
+    public String issueAdminToken() {
+        return jwtProvider.issueAdminToken();
+    }
+
 }

--- a/src/main/java/sopt/org/hmh/global/auth/jwt/exception/JwtError.java
+++ b/src/main/java/sopt/org/hmh/global/auth/jwt/exception/JwtError.java
@@ -26,11 +26,14 @@ public enum JwtError implements ErrorBase {
     INVALID_IDENTITY_TOKEN_CLAIMS(HttpStatus.UNAUTHORIZED, "유효하지 않은 애플 아이덴티티 토큰 클레임입니다."),
     UNABLE_TO_CREATE_APPLE_PUBLIC_KEY(HttpStatus.UNAUTHORIZED, "애플 로그인 중 퍼블릭 키 생성에 문제가 발생했습니다."),
 
+    INVALID_ADMIN_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 관리자 액세스 토큰입니다."),
+
     // 404 NOT FOUND
     NOT_FOUND_REFRESH_TOKEN_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 리프레시 토큰입니다."),
 
     // 500 INTERNAL ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+
     private final HttpStatus status;
     private final String errorMessage;
 

--- a/src/main/java/sopt/org/hmh/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/sopt/org/hmh/global/auth/security/JwtAuthenticationFilter.java
@@ -11,14 +11,11 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import sopt.org.hmh.global.auth.jwt.JwtConstants;
 import sopt.org.hmh.global.auth.jwt.JwtProvider;
 import sopt.org.hmh.global.auth.jwt.JwtValidator;
-import sopt.org.hmh.global.auth.jwt.exception.JwtError;
-import sopt.org.hmh.global.auth.jwt.exception.JwtException;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -34,11 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String getAccessToken(HttpServletRequest request) {
-        String accessToken = request.getHeader(JwtConstants.AUTHORIZATION);
-        if (StringUtils.hasText(accessToken) && accessToken.startsWith(JwtConstants.BEARER)) {
-            return accessToken.substring(JwtConstants.BEARER.length());
-        }
-        throw new JwtException(JwtError.INVALID_ACCESS_TOKEN);
+        return request.getHeader(JwtConstants.AUTHORIZATION);
     }
 
     private void doAuthentication(HttpServletRequest request, String subjectId) {

--- a/src/main/java/sopt/org/hmh/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/sopt/org/hmh/global/auth/security/JwtAuthenticationFilter.java
@@ -41,8 +41,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         throw new JwtException(JwtError.INVALID_ACCESS_TOKEN);
     }
 
-    private void doAuthentication(HttpServletRequest request, Long userId) {
-        UserAuthentication authentication = createUserAuthentication(userId);
+    private void doAuthentication(HttpServletRequest request, String subjectId) {
+        UserAuthentication authentication = createUserAuthentication(subjectId);
         createAndSetWebAuthenticationDetails(request, authentication);
         SecurityContext securityContext = SecurityContextHolder.getContext();
         securityContext.setAuthentication(authentication);

--- a/src/main/java/sopt/org/hmh/global/auth/security/UserAuthentication.java
+++ b/src/main/java/sopt/org/hmh/global/auth/security/UserAuthentication.java
@@ -10,7 +10,7 @@ public class UserAuthentication extends UsernamePasswordAuthenticationToken {
         super(principal, credentials, authorities);
     }
 
-    public static UserAuthentication createUserAuthentication(Long userId) {
-        return new UserAuthentication(userId, null, null);
+    public static UserAuthentication createUserAuthentication(String subjectId) {
+        return new UserAuthentication(subjectId, null, null);
     }
 }

--- a/src/main/java/sopt/org/hmh/global/auth/security/ValidateAdminInterceptor.java
+++ b/src/main/java/sopt/org/hmh/global/auth/security/ValidateAdminInterceptor.java
@@ -1,0 +1,23 @@
+package sopt.org.hmh.global.auth.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import sopt.org.hmh.global.auth.jwt.JwtConstants;
+import sopt.org.hmh.global.auth.jwt.TokenService;
+
+@Component
+@RequiredArgsConstructor
+public class ValidateAdminInterceptor implements HandlerInterceptor {
+
+    private final TokenService tokenService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String accessToken = request.getHeader(JwtConstants.AUTHORIZATION);
+        tokenService.validateAdminToken(accessToken);
+        return true;
+    }
+}

--- a/src/main/java/sopt/org/hmh/global/config/SecurityConfig.java
+++ b/src/main/java/sopt/org/hmh/global/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
 
             // Authentication
             "/api/v1/user/login",
+            "/api/v1/admin/login",
             "/api/v1/user/reissue",
             "/api/v1/user/signup",
             "/api/v1/user/social/token/kakao",

--- a/src/main/java/sopt/org/hmh/global/config/WebConfig.java
+++ b/src/main/java/sopt/org/hmh/global/config/WebConfig.java
@@ -1,14 +1,22 @@
 package sopt.org.hmh.global.config;
 
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import sopt.org.hmh.global.auth.UserIdArgumentResolver;
+import sopt.org.hmh.global.auth.security.ValidateAdminInterceptor;
 
 @Configuration
+@EnableWebMvc
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final ValidateAdminInterceptor validateAdminInterceptor;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -22,5 +30,12 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new UserIdArgumentResolver());
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(validateAdminInterceptor)
+                .addPathPatterns("/api/v1/admin/**")
+                .excludePathPatterns("/api/v1/admin/login");
     }
 }


### PR DESCRIPTION
<!--- 
❗️ check List 
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

❗️ 이슈 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
- deploy 배포 관련
-->

## Related issue 🚀
- closed #171 

## Work Description 💚
- admin api를 추가하였습니다.
- admin login을 통해 jwt의 subject 값이 "ADMIN"인 토큰을 발급하고, 그 토큰을 이용해서 admin api를 이용할 수 있도록 하였습니다.
- admin jwt의 검증은 spring intercepter를 이용하여 controller에 요청이 가기 전, jwtValidator를 이용해서 jwt의 subject값이 "ADMIN"인지 검증하도록 하였습니다.

### Admin login api
application.yml에 있는 값인 admin-auth-code값을 이용하여 jwt의 subject 값이 "ADMIN"인 토큰을 발급합니다.
이 토큰은 spring interceptor를 이용해 `api/v1/admin`으로 시작되는 모든 api를 검증됩니다. (`api/v1/admin/login`)은 제외됩니다.

### Admin 유저 정보 변경 api
admin jwt를 이용해 유저의 이름 및 포인트를 변경할 수 있도록 합니다.

### Admin 일별 챌린지 상태 변경 api
admin jwt를 이용해 dailyChallenge의 상태 및 챌린지 날짜를 변경할 수 있도록 합니다.
request로 보낸 statuses가 기존 dailyChallenge의 period와 맞지 않으면 에러를 발생시킵니다.

### Admin 회원 탈퇴 api
admin jwt를 이용해 특정 id의 회원을 탈퇴 시킵니다.
특정 id의 회원이 없다면 탈퇴시키지 않습니다.