### PR TITLE
modify - 일별챌린지 결과 전송 후 챌린지의 변경된 상태값들을 반환하도록 수정

### DIFF
--- a/src/main/java/sopt/org/hmh/domain/challenge/domain/Challenge.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/domain/Challenge.java
@@ -39,6 +39,7 @@ public class Challenge extends BaseTimeEntity {
     private List<ChallengeApp> apps;
 
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OrderBy("challengeDate ASC")
     private List<DailyChallenge> historyDailyChallenges;
 
     @Builder

--- a/src/main/java/sopt/org/hmh/domain/challenge/dto/response/ChallengeResponse.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/dto/response/ChallengeResponse.java
@@ -26,7 +26,6 @@ public record ChallengeResponse(
                 .period(challenge.getPeriod())
                 .statuses(challenge.getHistoryDailyChallenges()
                         .stream()
-                        .sorted(Comparator.comparing(DailyChallenge::getChallengeDate))
                         .map(DailyChallenge::getStatus)
                         .toList())
                 .todayIndex(calculateTodayIndex(challenge, LocalDate.now(ZoneId.of(timeZone))))

--- a/src/main/java/sopt/org/hmh/domain/challenge/dto/response/ChallengeResponse.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/dto/response/ChallengeResponse.java
@@ -9,6 +9,7 @@ import sopt.org.hmh.domain.challenge.domain.Challenge;
 import sopt.org.hmh.domain.dailychallenge.domain.DailyChallenge;
 import sopt.org.hmh.domain.dailychallenge.domain.Status;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Builder
@@ -25,6 +26,7 @@ public record ChallengeResponse(
                 .period(challenge.getPeriod())
                 .statuses(challenge.getHistoryDailyChallenges()
                         .stream()
+                        .sorted(Comparator.comparing(DailyChallenge::getChallengeDate))
                         .map(DailyChallenge::getStatus)
                         .toList())
                 .todayIndex(calculateTodayIndex(challenge, LocalDate.now(ZoneId.of(timeZone))))

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeApi.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeApi.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import sopt.org.hmh.domain.dailychallenge.dto.request.FinishedDailyChallengeListRequest;
 import sopt.org.hmh.domain.dailychallenge.dto.request.FinishedDailyChallengeStatusListRequest;
+import sopt.org.hmh.domain.dailychallenge.dto.response.ChallengeStatusesResponse;
 import sopt.org.hmh.global.auth.jwt.JwtConstants;
 import sopt.org.hmh.global.common.constant.CustomHeaderType;
 import sopt.org.hmh.global.common.response.BaseResponse;
@@ -34,7 +35,7 @@ public interface DailyChallengeApi {
                             responseCode = "500",
                             description = "서버 내부 오류입니다.",
                             content = @Content)})
-    ResponseEntity<BaseResponse<EmptyJsonResponse>> orderAddHistoryDailyChallenge(
+    ResponseEntity<BaseResponse<ChallengeStatusesResponse>> orderAddHistoryDailyChallenge(
             @Parameter(hidden = true) final Long userId,
             @RequestHeader(CustomHeaderType.TIME_ZONE) final String os,
             @RequestHeader(CustomHeaderType.TIME_ZONE) final String timeZone,
@@ -55,7 +56,7 @@ public interface DailyChallengeApi {
                             responseCode = "500",
                             description = "서버 내부 오류입니다.",
                             content = @Content)})
-    ResponseEntity<BaseResponse<EmptyJsonResponse>> orderChangeStatusDailyChallenge(
+    ResponseEntity<BaseResponse<ChallengeStatusesResponse>> orderChangeStatusDailyChallenge(
             @Parameter(hidden = true) final Long userId,
             @RequestHeader(CustomHeaderType.TIME_ZONE) final String timeZone,
             @RequestBody final FinishedDailyChallengeStatusListRequest request

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
@@ -4,9 +4,12 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import sopt.org.hmh.domain.challenge.dto.response.ChallengeResponse;
+import sopt.org.hmh.domain.challenge.service.ChallengeFacade;
 import sopt.org.hmh.domain.dailychallenge.domain.exception.DailyChallengeSuccess;
 import sopt.org.hmh.domain.dailychallenge.dto.request.FinishedDailyChallengeListRequest;
 import sopt.org.hmh.domain.dailychallenge.dto.request.FinishedDailyChallengeStatusListRequest;
+import sopt.org.hmh.domain.dailychallenge.dto.response.ChallengeStatusesResponse;
 import sopt.org.hmh.domain.dailychallenge.service.DailyChallengeFacade;
 import sopt.org.hmh.global.auth.UserId;
 import sopt.org.hmh.global.common.constant.CustomHeaderType;
@@ -22,7 +25,7 @@ public class DailyChallengeController implements DailyChallengeApi {
 
     @Override
     @PostMapping("/finish")
-    public ResponseEntity<BaseResponse<EmptyJsonResponse>> orderAddHistoryDailyChallenge(
+    public ResponseEntity<BaseResponse<ChallengeStatusesResponse>> orderAddHistoryDailyChallenge(
             @UserId final Long userId,
             @RequestHeader(CustomHeaderType.OS) final String os,
             @RequestHeader(CustomHeaderType.TIME_ZONE) final String timeZone,
@@ -31,12 +34,13 @@ public class DailyChallengeController implements DailyChallengeApi {
         dailyChallengeFacade.addFinishedDailyChallengeHistory(userId, request, os);
         return ResponseEntity
                 .status(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS.getHttpStatus())
-                .body(BaseResponse.success(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS, new EmptyJsonResponse()));
+                .body(BaseResponse.success(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS,
+                        new ChallengeStatusesResponse(dailyChallengeFacade.getChangedChallengeStatuses(userId))));
     }
 
     @Override
     @PostMapping("/success")
-    public ResponseEntity<BaseResponse<EmptyJsonResponse>> orderChangeStatusDailyChallenge(
+    public ResponseEntity<BaseResponse<ChallengeStatusesResponse>> orderChangeStatusDailyChallenge(
             @UserId final Long userId,
             @RequestHeader(CustomHeaderType.TIME_ZONE) final String timeZone,
             @RequestBody final FinishedDailyChallengeStatusListRequest request
@@ -44,6 +48,7 @@ public class DailyChallengeController implements DailyChallengeApi {
         dailyChallengeFacade.changeDailyChallengeStatusByIsSuccess(userId, request);
         return ResponseEntity
                 .status(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS.getHttpStatus())
-                .body(BaseResponse.success(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS, new EmptyJsonResponse()));
+                .body(BaseResponse.success(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS,
+                        new ChallengeStatusesResponse(dailyChallengeFacade.getChangedChallengeStatuses(userId))));
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
@@ -31,11 +31,10 @@ public class DailyChallengeController implements DailyChallengeApi {
             @RequestHeader(CustomHeaderType.TIME_ZONE) final String timeZone,
             @RequestBody @Valid final FinishedDailyChallengeListRequest request
     ) {
-        dailyChallengeFacade.addFinishedDailyChallengeHistory(userId, request, os);
         return ResponseEntity
                 .status(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS.getHttpStatus())
                 .body(BaseResponse.success(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS,
-                        new ChallengeStatusesResponse(dailyChallengeFacade.getChangedChallengeStatuses(userId))));
+                        new ChallengeStatusesResponse(dailyChallengeFacade.addFinishedDailyChallengeHistory(userId, request, os))));
     }
 
     @Override
@@ -45,10 +44,9 @@ public class DailyChallengeController implements DailyChallengeApi {
             @RequestHeader(CustomHeaderType.TIME_ZONE) final String timeZone,
             @RequestBody final FinishedDailyChallengeStatusListRequest request
     ) {
-        dailyChallengeFacade.changeDailyChallengeStatusByIsSuccess(userId, request);
         return ResponseEntity
                 .status(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS.getHttpStatus())
                 .body(BaseResponse.success(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS,
-                        new ChallengeStatusesResponse(dailyChallengeFacade.getChangedChallengeStatuses(userId))));
+                        new ChallengeStatusesResponse(dailyChallengeFacade.changeDailyChallengeStatusByIsSuccess(userId, request))));
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/dto/response/ChallengeStatusesResponse.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/dto/response/ChallengeStatusesResponse.java
@@ -1,0 +1,10 @@
+package sopt.org.hmh.domain.dailychallenge.dto.response;
+
+import sopt.org.hmh.domain.dailychallenge.domain.Status;
+
+import java.util.List;
+
+public record ChallengeStatusesResponse(
+        List<Status> statuses
+) {
+}

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/repository/DailyChallengeJpaRepository.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/repository/DailyChallengeJpaRepository.java
@@ -10,5 +10,5 @@ public interface DailyChallengeJpaRepository extends JpaRepository<DailyChalleng
 
     Optional<DailyChallenge> findByChallengeDateAndUserId(LocalDate challengeDate, Long userId);
 
-    List<DailyChallenge> findAllByChallengeIdOrderByChallengeDate(Long challengeId);
+    List<DailyChallenge> findAllByChallengeId(Long challengeId);
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/repository/DailyChallengeRepository.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/repository/DailyChallengeRepository.java
@@ -11,7 +11,7 @@ public interface DailyChallengeRepository {
 
     Optional<DailyChallenge> findByChallengeDateAndUserId(LocalDate challengeDate, Long userId);
 
-    List<DailyChallenge> findAllByChallengeIdOrderByChallengeDate(Long challengeId);
+    List<DailyChallenge> findAllByChallengeId(Long challengeId);
 
     boolean existsByUserIdAndChallengeDateIn(Long userId, List<LocalDate> localDates);
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/repository/DailyChallengeRepositoryImpl.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/repository/DailyChallengeRepositoryImpl.java
@@ -27,8 +27,8 @@ public class DailyChallengeRepositoryImpl implements DailyChallengeRepository {
     }
 
     @Override
-    public List<DailyChallenge> findAllByChallengeIdOrderByChallengeDate(Long challengeId) {
-        return dailyChallengeJpaRepository.findAllByChallengeIdOrderByChallengeDate(challengeId);
+    public List<DailyChallenge> findAllByChallengeId(Long challengeId) {
+        return dailyChallengeJpaRepository.findAllByChallengeId(challengeId);
     }
 
     @Override

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sopt.org.hmh.domain.app.domain.ChallengeApp;
 import sopt.org.hmh.domain.app.service.HistoryAppService;
+import sopt.org.hmh.domain.challenge.domain.Challenge;
 import sopt.org.hmh.domain.challenge.service.ChallengeService;
 import sopt.org.hmh.domain.dailychallenge.domain.DailyChallenge;
 import sopt.org.hmh.domain.dailychallenge.domain.Status;
@@ -23,27 +24,31 @@ public class DailyChallengeFacade {
     private final UserService userService;
 
     @Transactional
-    public void addFinishedDailyChallengeHistory(Long userId, FinishedDailyChallengeListRequest requests, String os) {
-        Long currentChallengeId = userService.getCurrentChallengeIdByUserId(userId);
-        List<ChallengeApp> currentChallengeApps =
-                challengeService.getCurrentChallengeAppByChallengeId(currentChallengeId);
+    public List<Status> addFinishedDailyChallengeHistory(Long userId, FinishedDailyChallengeListRequest requests, String os) {
+        Challenge challenge = challengeService.findByIdOrElseThrow(userService.getCurrentChallengeIdByUserId(userId));
 
         requests.finishedDailyChallenges().forEach(request -> {
             DailyChallenge dailyChallenge =
                     dailyChallengeService.findDailyChallengeByChallengeIdAndChallengePeriodIndex(
-                            currentChallengeId, request.challengePeriodIndex());
+                            challenge.getId(), request.challengePeriodIndex());
             dailyChallengeService.changeStatusByCurrentStatus(dailyChallenge);
-            historyAppService.addHistoryApp(currentChallengeApps, request.apps(), dailyChallenge, os);
+            historyAppService.addHistoryApp(challenge.getApps(), request.apps(), dailyChallenge, os);
         });
+
+        return challenge.getHistoryDailyChallenges()
+                .stream()
+                .map(DailyChallenge::getStatus)
+                .toList();
     }
 
     @Transactional
-    public void changeDailyChallengeStatusByIsSuccess(Long userId, FinishedDailyChallengeStatusListRequest requests) {
-        Long currentChallengeId = userService.getCurrentChallengeIdByUserId(userId);
+    public List<Status> changeDailyChallengeStatusByIsSuccess(Long userId, FinishedDailyChallengeStatusListRequest requests) {
+        Challenge challenge = challengeService.findByIdOrElseThrow(userService.getCurrentChallengeIdByUserId(userId));
+
         requests.finishedDailyChallenges().forEach(request -> {
             DailyChallenge dailyChallenge =
                     dailyChallengeService.findDailyChallengeByChallengeIdAndChallengePeriodIndex(
-                            currentChallengeId, request.challengePeriodIndex());
+                            challenge.getId(), request.challengePeriodIndex());
             if (request.isSuccess()) {
                 dailyChallengeService.validateDailyChallengeStatus(dailyChallenge.getStatus(), List.of(Status.NONE));
                 dailyChallenge.changeStatus(Status.UNEARNED);
@@ -53,12 +58,8 @@ public class DailyChallengeFacade {
                 dailyChallenge.changeStatus(Status.FAILURE);
             }
         });
-    }
 
-    public List<Status> getChangedChallengeStatuses(Long userId) {
-        Long currentChallengeId = userService.getCurrentChallengeIdByUserId(userId);
-        return challengeService.findByIdOrElseThrow(currentChallengeId)
-                .getHistoryDailyChallenges()
+        return challenge.getHistoryDailyChallenges()
                 .stream()
                 .map(DailyChallenge::getStatus)
                 .toList();

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
@@ -30,8 +30,7 @@ public class DailyChallengeFacade {
 
         request.finishedDailyChallenges().forEach(challengeRequest -> {
             DailyChallenge dailyChallenge =
-                    dailyChallengeService.findDailyChallengeByChallengeIdAndChallengePeriodIndex(
-                            challenge.getId(), request.challengePeriodIndex());
+                    challenge.getHistoryDailyChallenges().get(challengeRequest.challengePeriodIndex());
             dailyChallengeService.changeStatusByCurrentStatus(dailyChallenge);
             historyAppService.addHistoryApp(challenge.getApps(), challengeRequest.apps(), dailyChallenge, os);
         });
@@ -45,8 +44,7 @@ public class DailyChallengeFacade {
 
         request.finishedDailyChallenges().forEach(challengeRequest -> {
             DailyChallenge dailyChallenge =
-                    dailyChallengeService.findDailyChallengeByChallengeIdAndChallengePeriodIndex(
-                            challenge.getId(), request.challengePeriodIndex());
+                    challenge.getHistoryDailyChallenges().get(challengeRequest.challengePeriodIndex());
             if (challengeRequest.isSuccess()) {
                 dailyChallengeService.validateDailyChallengeStatus(dailyChallenge.getStatus(), List.of(Status.NONE));
                 dailyChallenge.changeStatus(Status.UNEARNED);

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
@@ -4,7 +4,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import sopt.org.hmh.domain.app.domain.ChallengeApp;
 import sopt.org.hmh.domain.app.service.HistoryAppService;
 import sopt.org.hmh.domain.challenge.domain.Challenge;
 import sopt.org.hmh.domain.challenge.service.ChallengeService;
@@ -28,13 +27,13 @@ public class DailyChallengeFacade {
         Challenge challenge = challengeService.findByIdOrElseThrow(userService.getCurrentChallengeIdByUserId(userId));
 
         request.finishedDailyChallenges().forEach(challengeRequest -> {
-            DailyChallenge dailyChallenge =
-                    challenge.getHistoryDailyChallenges().get(challengeRequest.challengePeriodIndex());
+            DailyChallenge dailyChallenge = dailyChallengeService
+                    .findDailyChallengeByChallengePeriodIndex(challenge, challengeRequest.challengePeriodIndex());
             dailyChallengeService.changeStatusByCurrentStatus(dailyChallenge);
             historyAppService.addHistoryApp(challenge.getApps(), challengeRequest.apps(), dailyChallenge, os);
         });
 
-        return getHistoryDailyChallengesOrderByChallengeDate(challenge);
+        return getHistoryDailyChallenges(challenge);
     }
 
     @Transactional
@@ -42,8 +41,8 @@ public class DailyChallengeFacade {
         Challenge challenge = challengeService.findByIdOrElseThrow(userService.getCurrentChallengeIdByUserId(userId));
 
         request.finishedDailyChallenges().forEach(challengeRequest -> {
-            DailyChallenge dailyChallenge =
-                    challenge.getHistoryDailyChallenges().get(challengeRequest.challengePeriodIndex());
+            DailyChallenge dailyChallenge = dailyChallengeService
+                    .findDailyChallengeByChallengePeriodIndex(challenge, challengeRequest.challengePeriodIndex());
             if (challengeRequest.isSuccess()) {
                 dailyChallengeService.validateDailyChallengeStatus(dailyChallenge.getStatus(), List.of(Status.NONE));
                 dailyChallenge.changeStatus(Status.UNEARNED);
@@ -54,10 +53,10 @@ public class DailyChallengeFacade {
             }
         });
 
-        return getHistoryDailyChallengesOrderByChallengeDate(challenge);
+        return getHistoryDailyChallenges(challenge);
     }
 
-    private List<Status> getHistoryDailyChallengesOrderByChallengeDate(Challenge challenge) {
+    private List<Status> getHistoryDailyChallenges(Challenge challenge) {
         return challenge.getHistoryDailyChallenges()
                 .stream()
                 .map(DailyChallenge::getStatus)

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
@@ -1,5 +1,6 @@
 package sopt.org.hmh.domain.dailychallenge.service;
 
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,6 +38,7 @@ public class DailyChallengeFacade {
 
         return challenge.getHistoryDailyChallenges()
                 .stream()
+                .sorted(Comparator.comparing(DailyChallenge::getChallengeDate))
                 .map(DailyChallenge::getStatus)
                 .toList();
     }
@@ -61,6 +63,7 @@ public class DailyChallengeFacade {
 
         return challenge.getHistoryDailyChallenges()
                 .stream()
+                .sorted(Comparator.comparing(DailyChallenge::getChallengeDate))
                 .map(DailyChallenge::getStatus)
                 .toList();
     }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
@@ -25,29 +25,29 @@ public class DailyChallengeFacade {
     private final UserService userService;
 
     @Transactional
-    public List<Status> addFinishedDailyChallengeHistory(Long userId, FinishedDailyChallengeListRequest requests, String os) {
+    public List<Status> addFinishedDailyChallengeHistory(Long userId, FinishedDailyChallengeListRequest request, String os) {
         Challenge challenge = challengeService.findByIdOrElseThrow(userService.getCurrentChallengeIdByUserId(userId));
 
-        requests.finishedDailyChallenges().forEach(request -> {
+        request.finishedDailyChallenges().forEach(challengeRequest -> {
             DailyChallenge dailyChallenge =
                     dailyChallengeService.findDailyChallengeByChallengeIdAndChallengePeriodIndex(
                             challenge.getId(), request.challengePeriodIndex());
             dailyChallengeService.changeStatusByCurrentStatus(dailyChallenge);
-            historyAppService.addHistoryApp(challenge.getApps(), request.apps(), dailyChallenge, os);
+            historyAppService.addHistoryApp(challenge.getApps(), challengeRequest.apps(), dailyChallenge, os);
         });
 
         return getHistoryDailyChallengesOrderByChallengeDate(challenge);
     }
 
     @Transactional
-    public List<Status> changeDailyChallengeStatusByIsSuccess(Long userId, FinishedDailyChallengeStatusListRequest requests) {
+    public List<Status> changeDailyChallengeStatusByIsSuccess(Long userId, FinishedDailyChallengeStatusListRequest request) {
         Challenge challenge = challengeService.findByIdOrElseThrow(userService.getCurrentChallengeIdByUserId(userId));
 
-        requests.finishedDailyChallenges().forEach(request -> {
+        request.finishedDailyChallenges().forEach(challengeRequest -> {
             DailyChallenge dailyChallenge =
                     dailyChallengeService.findDailyChallengeByChallengeIdAndChallengePeriodIndex(
                             challenge.getId(), request.challengePeriodIndex());
-            if (request.isSuccess()) {
+            if (challengeRequest.isSuccess()) {
                 dailyChallengeService.validateDailyChallengeStatus(dailyChallenge.getStatus(), List.of(Status.NONE));
                 dailyChallenge.changeStatus(Status.UNEARNED);
             } else {

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
@@ -54,4 +54,13 @@ public class DailyChallengeFacade {
             }
         });
     }
+
+    public List<Status> getChangedChallengeStatuses(Long userId) {
+        Long currentChallengeId = userService.getCurrentChallengeIdByUserId(userId);
+        return challengeService.findByIdOrElseThrow(currentChallengeId)
+                .getHistoryDailyChallenges()
+                .stream()
+                .map(DailyChallenge::getStatus)
+                .toList();
+    }
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
@@ -36,11 +36,7 @@ public class DailyChallengeFacade {
             historyAppService.addHistoryApp(challenge.getApps(), request.apps(), dailyChallenge, os);
         });
 
-        return challenge.getHistoryDailyChallenges()
-                .stream()
-                .sorted(Comparator.comparing(DailyChallenge::getChallengeDate))
-                .map(DailyChallenge::getStatus)
-                .toList();
+        return getHistoryDailyChallengesOrderByChallengeDate(challenge);
     }
 
     @Transactional
@@ -61,6 +57,10 @@ public class DailyChallengeFacade {
             }
         });
 
+        return getHistoryDailyChallengesOrderByChallengeDate(challenge);
+    }
+
+    private List<Status> getHistoryDailyChallengesOrderByChallengeDate(Challenge challenge) {
         return challenge.getHistoryDailyChallenges()
                 .stream()
                 .sorted(Comparator.comparing(DailyChallenge::getChallengeDate))

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
@@ -1,6 +1,5 @@
 package sopt.org.hmh.domain.dailychallenge.service;
 
-import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -61,7 +60,6 @@ public class DailyChallengeFacade {
     private List<Status> getHistoryDailyChallengesOrderByChallengeDate(Challenge challenge) {
         return challenge.getHistoryDailyChallenges()
                 .stream()
-                .sorted(Comparator.comparing(DailyChallenge::getChallengeDate))
                 .map(DailyChallenge::getStatus)
                 .toList();
     }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
@@ -85,12 +85,12 @@ public class DailyChallengeService {
                 .toList();
     }
 
-    public List<DailyChallenge> getDailyChallengesByChallengeIdOrderByChallengeDate(Long challengeId) {
-        return dailyChallengeRepository.findAllByChallengeIdOrderByChallengeDate(challengeId);
+    public List<DailyChallenge> getDailyChallengesByChallengeId(Long challengeId) {
+        return dailyChallengeRepository.findAllByChallengeId(challengeId);
     }
 
     public void changeInfoOfDailyChallenges(Long challengeId, List<Status> statuses, LocalDate challengeDate) {
-        List<DailyChallenge> dailyChallenges = this.getDailyChallengesByChallengeIdOrderByChallengeDate(challengeId);
+        List<DailyChallenge> dailyChallenges = this.getDailyChallengesByChallengeId(challengeId);
         changeStatusOfDailyChallenges(dailyChallenges, statuses);
         changeChallengeDateOfDailyChallenges(dailyChallenges, challengeDate);
     }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
@@ -24,9 +24,9 @@ public class DailyChallengeService {
                 .orElseThrow(() -> new DailyChallengeException(DailyChallengeError.DAILY_CHALLENGE_NOT_FOUND));
     }
 
-    public DailyChallenge findDailyChallengeByChallengeIdAndChallengePeriodIndex(Long challengeId, Integer challengePeriodIndex) {
+    public DailyChallenge findDailyChallengeByChallengePeriodIndex(Challenge challenge, Integer challengePeriodIndex) {
         return Optional.ofNullable(
-                dailyChallengeRepository.findAllByChallengeIdOrderByChallengeDate(challengeId).get(challengePeriodIndex)
+                challenge.getHistoryDailyChallenges().get(challengePeriodIndex)
         ).orElseThrow(() -> new DailyChallengeException(DailyChallengeError.DAILY_CHALLENGE_PERIOD_INDEX_NOT_FOUND));
     }
 


### PR DESCRIPTION
<!--- 
❗️ check List 
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

❗️ 이슈 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
- deploy 배포 관련
-->

## Related issue 🚀
- closed #183 

## Work Description 💚
- 기존에 data에 아무것도 반환해주지 않는 방식에서 챌린지의 status들 목록을 반환하도록 수정하였습니다.
- `~/success`, `~/finish` api 2개에 적용하였습니다.

## PR 참고 사항
- 테스트는 iOS 계정으로 진행해서 iOS용 api 메소드에만 테스트 해보았습니다.

## 포스트맨 테스트
<img width="516" alt="스크린샷 2024-07-19 17 34 36" src="https://github.com/user-attachments/assets/6868041f-484d-4f87-94b9-c24ee736ebdf">

