### PR TITLE
fix - 챌린지 생성 시 중복된 일별 챌린지를 생성하지 않도록 유효성 검사 로직 추가

### DIFF
--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/exception/DailyChallengeError.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/exception/DailyChallengeError.java
@@ -9,8 +9,8 @@ public enum DailyChallengeError implements ErrorBase {
 
     DAILY_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "일별 챌린지를 찾을 수 없습니다."),
     DAILY_CHALLENGE_PERIOD_INDEX_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 인덱스의 일별 챌린지를 찾을 수 없습니다."),
-    DAILY_CHALLENGE_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 일별 챌린지입니다.")
-    ;
+    DAILY_CHALLENGE_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 일별 챌린지입니다."),
+    DAILY_CHALLENGE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 일별 챌린지입니다.");
 
     private final HttpStatus status;
     private final String errorMessage;

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/repository/DailyChallengeRepository.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/repository/DailyChallengeRepository.java
@@ -13,4 +13,5 @@ public interface DailyChallengeRepository {
 
     List<DailyChallenge> findAllByChallengeIdOrderByChallengeDate(Long challengeId);
 
+    boolean existsByUserIdAndChallengeDateIn(Long userId, List<LocalDate> localDates);
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/repository/DailyChallengeRepositoryImpl.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/repository/DailyChallengeRepositoryImpl.java
@@ -1,17 +1,20 @@
 package sopt.org.hmh.domain.dailychallenge.repository;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import sopt.org.hmh.domain.dailychallenge.domain.DailyChallenge;
+import sopt.org.hmh.domain.dailychallenge.domain.QDailyChallenge;
 
 @Repository
 @RequiredArgsConstructor
 public class DailyChallengeRepositoryImpl implements DailyChallengeRepository {
 
     private final DailyChallengeJpaRepository dailyChallengeJpaRepository;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public void saveAll(List<DailyChallenge> dailyChallengeByChallengePeriod) {
@@ -26,5 +29,16 @@ public class DailyChallengeRepositoryImpl implements DailyChallengeRepository {
     @Override
     public List<DailyChallenge> findAllByChallengeIdOrderByChallengeDate(Long challengeId) {
         return dailyChallengeJpaRepository.findAllByChallengeIdOrderByChallengeDate(challengeId);
+    }
+
+    @Override
+    public boolean existsByUserIdAndChallengeDateIn(Long userId, List<LocalDate> localDates) {
+        QDailyChallenge dailyChallenge = QDailyChallenge.dailyChallenge;
+        Integer fetchOne = queryFactory.selectOne()
+                .from(dailyChallenge)
+                .where(dailyChallenge.userId.eq(userId)
+                        .and(dailyChallenge.challengeDate.in(localDates)))
+                .fetchFirst();
+        return fetchOne != null;
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
@@ -59,7 +59,18 @@ public class DailyChallengeService {
     }
 
     public void addDailyChallenge(Challenge challenge) {
+        validateDuplicateDailyChallenge(challenge);
         dailyChallengeRepository.saveAll(createDailyChallengeByChallengePeriod(challenge));
+    }
+
+    private void validateDuplicateDailyChallenge(Challenge challenge) {
+        List<LocalDate> localDatesToCheck = IntStream.range(0, challenge.getPeriod())
+                .mapToObj(i -> challenge.getStartDate().plusDays(i))
+                .toList();
+
+        if (dailyChallengeRepository.existsByUserIdAndChallengeDateIn(challenge.getUserId(), localDatesToCheck)) {
+            throw new DailyChallengeException(DailyChallengeError.DAILY_CHALLENGE_ALREADY_EXISTS);
+        }
     }
 
     private List<DailyChallenge> createDailyChallengeByChallengePeriod(Challenge challenge) {


### PR DESCRIPTION
## Related issue 🚀
- closed #162 

## Work Description 💚
- 챌린지 생성 시에 중복된 일별 챌린지를 생성하지 않도록 유효성 검사 로직을 추가하였습니다.

## PR 참고 사항
- Querydsl을 활용하여 userId와 challengeDate가 같은 일별 챌린지가 하나씩 있는지 확인하는 것이 아닌, 아래의 쿼리를 이용해 한 번에 일별 챌린지가 존재하는지 확인하도록 하였습니다.
- selectOne과 fetchFirst를 활용하여 exist의 쿼리 성능을 최대한 끌어내고자 하였습니다.
- [참고 블로그](https://jojoldu.tistory.com/516)입니다.

```
select
        1 
    from
        daily_challenge dc1_0 
    where
        dc1_0.user_id=? 
        and dc1_0.challenge_date in (?, ?, ?, ?, ?, ?, ?) 
    limit
        ?
```