### PR TITLE
fix - #188 기존 챌린지 id 값 불러오는 메소드 순서 수정

### DIFF
--- a/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/challenge/service/ChallengeFacade.java
@@ -29,11 +29,10 @@ public class ChallengeFacade {
     @Transactional
     public void startNewChallenge(NewChallengeOrder newChallengeOrder) {
         Challenge newChallenge = challengeService.addChallenge(newChallengeOrder.toChallengeEntity());
-        userService.changeCurrentChallengeIdByUserId(newChallengeOrder.getUserId(), newChallenge.getId());
-
         dailyChallengeService.addDailyChallenge(newChallenge);
 
         this.addAppsByNewChallengeOrder(newChallengeOrder, newChallenge);
+        userService.changeCurrentChallengeIdByUserId(newChallengeOrder.getUserId(), newChallenge.getId());
     }
 
     private void addAppsByNewChallengeOrder(NewChallengeOrder newChallengeOrder, Challenge newChallenge) {

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
@@ -34,7 +34,7 @@ public class DailyChallengeController implements DailyChallengeApi {
         return ResponseEntity
                 .status(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS.getHttpStatus())
                 .body(BaseResponse.success(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS,
-                        new ChallengeStatusesResponse(dailyChallengeFacade.addFinishedDailyChallengeHistory(userId, request, os))));
+                        new ChallengeStatusesResponse(dailyChallengeFacade.addFinishedDailyChallengeHistory(userId, request, os, timeZone))));
     }
 
     @Override

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/controller/DailyChallengeController.java
@@ -47,6 +47,6 @@ public class DailyChallengeController implements DailyChallengeApi {
         return ResponseEntity
                 .status(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS.getHttpStatus())
                 .body(BaseResponse.success(DailyChallengeSuccess.SEND_FINISHED_DAILY_CHALLENGE_SUCCESS,
-                        new ChallengeStatusesResponse(dailyChallengeFacade.changeDailyChallengeStatusByIsSuccess(userId, request))));
+                        new ChallengeStatusesResponse(dailyChallengeFacade.changeDailyChallengeStatusByIsSuccess(userId, request, timeZone))));
     }
 }

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/exception/DailyChallengeError.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/domain/exception/DailyChallengeError.java
@@ -10,7 +10,8 @@ public enum DailyChallengeError implements ErrorBase {
     DAILY_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "일별 챌린지를 찾을 수 없습니다."),
     DAILY_CHALLENGE_PERIOD_INDEX_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 인덱스의 일별 챌린지를 찾을 수 없습니다."),
     DAILY_CHALLENGE_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 일별 챌린지입니다."),
-    DAILY_CHALLENGE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 일별 챌린지입니다.");
+    DAILY_CHALLENGE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 일별 챌린지입니다."),
+    PERIOD_INDEX_NOT_VALID(HttpStatus.BAD_REQUEST, "지난 날의 정보만 전송할 수 있습니다.");
 
     private final HttpStatus status;
     private final String errorMessage;

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
@@ -31,6 +31,7 @@ public class DailyChallengeFacade {
 
         request.finishedDailyChallenges().forEach(challengeRequest -> {
             dailyChallengeService.validatePeriodIndex(challengeRequest.challengePeriodIndex(), todayIndex);
+
             DailyChallenge dailyChallenge = dailyChallengeService
                     .findDailyChallengeByChallengePeriodIndex(challenge, challengeRequest.challengePeriodIndex());
             dailyChallengeService.changeStatusByCurrentStatus(dailyChallenge);
@@ -41,10 +42,13 @@ public class DailyChallengeFacade {
     }
 
     @Transactional
-    public List<Status> changeDailyChallengeStatusByIsSuccess(Long userId, FinishedDailyChallengeStatusListRequest request) {
+    public List<Status> changeDailyChallengeStatusByIsSuccess(Long userId, FinishedDailyChallengeStatusListRequest request, String timeZone) {
         Challenge challenge = challengeService.findByIdOrElseThrow(userService.getCurrentChallengeIdByUserId(userId));
+        Integer todayIndex = dailyChallengeService.calculateTodayIndex(challenge, LocalDate.now(ZoneId.of(timeZone)));
 
         request.finishedDailyChallenges().forEach(challengeRequest -> {
+            dailyChallengeService.validatePeriodIndex(challengeRequest.challengePeriodIndex(), todayIndex);
+
             DailyChallenge dailyChallenge = dailyChallengeService
                     .findDailyChallengeByChallengePeriodIndex(challenge, challengeRequest.challengePeriodIndex());
             if (challengeRequest.isSuccess()) {

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeFacade.java
@@ -1,5 +1,7 @@
 package sopt.org.hmh.domain.dailychallenge.service;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,10 +25,12 @@ public class DailyChallengeFacade {
     private final UserService userService;
 
     @Transactional
-    public List<Status> addFinishedDailyChallengeHistory(Long userId, FinishedDailyChallengeListRequest request, String os) {
+    public List<Status> addFinishedDailyChallengeHistory(Long userId, FinishedDailyChallengeListRequest request, String os, String timeZone) {
         Challenge challenge = challengeService.findByIdOrElseThrow(userService.getCurrentChallengeIdByUserId(userId));
+        Integer todayIndex = dailyChallengeService.calculateTodayIndex(challenge, LocalDate.now(ZoneId.of(timeZone)));
 
         request.finishedDailyChallenges().forEach(challengeRequest -> {
+            dailyChallengeService.validatePeriodIndex(challengeRequest.challengePeriodIndex(), todayIndex);
             DailyChallenge dailyChallenge = dailyChallengeService
                     .findDailyChallengeByChallengePeriodIndex(challenge, challengeRequest.challengePeriodIndex());
             dailyChallengeService.changeStatusByCurrentStatus(dailyChallenge);

--- a/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
+++ b/src/main/java/sopt/org/hmh/domain/dailychallenge/service/DailyChallengeService.java
@@ -1,6 +1,7 @@
 package sopt.org.hmh.domain.dailychallenge.service;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -73,6 +74,10 @@ public class DailyChallengeService {
         }
     }
 
+    public void validatePeriodIndex(Integer periodIndex, Integer todayIndex) {
+        if (periodIndex >= todayIndex) throw new DailyChallengeException(DailyChallengeError.PERIOD_INDEX_NOT_VALID);
+    }
+
     private List<DailyChallenge> createDailyChallengeByChallengePeriod(Challenge challenge) {
         LocalDate startDate = challenge.getStartDate();
         Long userId = challenge.getUserId();
@@ -105,5 +110,11 @@ public class DailyChallengeService {
         for (int i = 0; i < dailyChallenges.size(); i++) {
             dailyChallenges.get(i).changeChallengeDate(challengeDate.plusDays(i));
         }
+    }
+
+    public Integer calculateTodayIndex(Challenge challenge, LocalDate now) {
+        final int COMPLETED_CHALLENGE_INDEX = -1;
+        int daysBetween = (int) ChronoUnit.DAYS.between(challenge.getStartDate(), now);
+        return (daysBetween >= challenge.getPeriod()) ? COMPLETED_CHALLENGE_INDEX : daysBetween;
     }
 }


### PR DESCRIPTION
<!--- 
❗️ check List 
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

❗️ 이슈 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
- deploy 배포 관련
-->

## Related issue 🚀
- closed #188 

## Work Description 💚
- 챌린지 생성 로직 내에서 챌린지값 id 수정하는 메소드와 기존 앱 목록 불러오는 메소드의 순서를 변경하였습니다.
- 챌린지 정보 전송 시 지난 날의 정보만 전송할 수 있도록 인덱스 유효성 검사를 추가하였습니다. (todayIndex<->periodIndex)

## PR 참고 사항
- 테스트코드의 중요성을 또 느꼈습니다 ++1